### PR TITLE
GraphQL/NestJS API validation

### DIFF
--- a/apps/api-nestjs/src/graphql/schema.ts
+++ b/apps/api-nestjs/src/graphql/schema.ts
@@ -21,6 +21,20 @@ export enum Duration {
     DAY = "DAY"
 }
 
+export enum ExchangeFrom {
+    ETH = "ETH"
+}
+
+export enum ExchangeTo {
+    USD = "USD"
+}
+
+export enum FilterEnum {
+    in = "in",
+    out = "out",
+    all = "all"
+}
+
 export enum SearchType {
     Transaction = "Transaction",
     Address = "Address",
@@ -194,10 +208,6 @@ export abstract class IQuery {
 
     abstract balanceByHash(hash: string): Balance | Promise<Balance>;
 
-    abstract blockMetricByHash(hash?: string): BlockMetric | Promise<BlockMetric>;
-
-    abstract blockMetrics(limit?: number, page?: number): BlockMetric[] | Promise<BlockMetric[]>;
-
     abstract blocks(limit?: number, page?: number): Block[] | Promise<Block[]>;
 
     abstract blockByHash(hash?: string): Block | Promise<Block>;
@@ -208,11 +218,15 @@ export abstract class IQuery {
 
     abstract totalNumberOfBlocks(): number | Promise<number>;
 
+    abstract blockMetricByHash(hash?: string): BlockMetric | Promise<BlockMetric>;
+
+    abstract blockMetrics(limit?: number, page?: number): BlockMetric[] | Promise<BlockMetric[]>;
+
     abstract contractByHash(hash?: string): Contract | Promise<Contract>;
 
     abstract contractsCreatedBy(creator?: string, limit?: number, page?: number): Contract[] | Promise<Contract[]>;
 
-    abstract quote(token: string, to: string): Quote | Promise<Quote>;
+    abstract quote(token: ExchangeFrom, to: ExchangeTo): Quote | Promise<Quote>;
 
     abstract tokenExchangeRates(filter: TokenExchangeRateFilter, limit?: number, page?: number): TokenExchangeRate[] | Promise<TokenExchangeRate[]>;
 
@@ -252,7 +266,7 @@ export abstract class IQuery {
 
     abstract addressTokenTransfers(address: string, limit?: number, page?: number): TokenTransfer[] | Promise<TokenTransfer[]>;
 
-    abstract addressTokenTransfersByHolder(address: string, holder: string, filter?: string, limit?: number, page?: number): TokenTransfer[] | Promise<TokenTransfer[]>;
+    abstract addressTokenTransfersByHolder(address: string, holder: string, filter?: FilterEnum, limit?: number, page?: number): TokenTransfer[] | Promise<TokenTransfer[]>;
 
     abstract tx(hash: string): Transaction | Promise<Transaction>;
 
@@ -260,7 +274,7 @@ export abstract class IQuery {
 
     abstract txsForBlock(hash: string): Transaction[] | Promise<Transaction[]>;
 
-    abstract txsForAddress(hash: string, filter?: string, limit?: number, page?: number): Transaction[] | Promise<Transaction[]>;
+    abstract txsForAddress(hash: string, filter?: FilterEnum, limit?: number, page?: number): Transaction[] | Promise<Transaction[]>;
 
     abstract totalNumberOfTransactions(): number | Promise<number>;
 

--- a/apps/api-nestjs/src/graphql/schema.ts
+++ b/apps/api-nestjs/src/graphql/schema.ts
@@ -222,9 +222,9 @@ export abstract class IQuery {
 
     abstract tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
 
-    abstract search(hash: string): Search | Promise<Search>;
-
     abstract processingMetadataById(id: string): ProcessingMetadata | Promise<ProcessingMetadata>;
+
+    abstract search(hash: string): Search | Promise<Search>;
 
     abstract totalTxs(duration: Duration): Statistic[] | Promise<Statistic[]>;
 

--- a/apps/api-nestjs/src/graphql/schema.ts
+++ b/apps/api-nestjs/src/graphql/schema.ts
@@ -208,6 +208,10 @@ export abstract class IQuery {
 
     abstract totalNumberOfBlocks(): number | Promise<number>;
 
+    abstract contractByHash(hash?: string): Contract | Promise<Contract>;
+
+    abstract contractsCreatedBy(creator?: string, limit?: number, page?: number): Contract[] | Promise<Contract[]>;
+
     abstract quote(token: string, to: string): Quote | Promise<Quote>;
 
     abstract tokenExchangeRates(filter: TokenExchangeRateFilter, limit?: number, page?: number): TokenExchangeRate[] | Promise<TokenExchangeRate[]>;
@@ -217,10 +221,6 @@ export abstract class IQuery {
     abstract tokenExchangeRateBySymbol(symbol: string): TokenExchangeRate | Promise<TokenExchangeRate>;
 
     abstract tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
-
-    abstract contractByHash(hash?: string): Contract | Promise<Contract>;
-
-    abstract contractsCreatedBy(creator?: string, limit?: number, page?: number): Contract[] | Promise<Contract[]>;
 
     abstract processingMetadataById(id: string): ProcessingMetadata | Promise<ProcessingMetadata>;
 

--- a/apps/api-nestjs/src/graphql/schema.ts
+++ b/apps/api-nestjs/src/graphql/schema.ts
@@ -222,9 +222,9 @@ export abstract class IQuery {
 
     abstract tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
 
-    abstract processingMetadataById(id: string): ProcessingMetadata | Promise<ProcessingMetadata>;
-
     abstract search(hash: string): Search | Promise<Search>;
+
+    abstract processingMetadataById(id: string): ProcessingMetadata | Promise<ProcessingMetadata>;
 
     abstract totalTxs(duration: Duration): Statistic[] | Promise<Statistic[]>;
 

--- a/apps/api-nestjs/src/graphql/schema.ts
+++ b/apps/api-nestjs/src/graphql/schema.ts
@@ -35,6 +35,11 @@ export enum FilterEnum {
     all = "all"
 }
 
+export enum Order {
+    asc = "asc",
+    desc = "desc"
+}
+
 export enum SearchType {
     Transaction = "Transaction",
     Address = "Address",
@@ -208,6 +213,10 @@ export abstract class IQuery {
 
     abstract balanceByHash(hash: string): Balance | Promise<Balance>;
 
+    abstract blockMetricByHash(hash?: string): BlockMetric | Promise<BlockMetric>;
+
+    abstract blockMetrics(limit?: number, page?: number): BlockMetric[] | Promise<BlockMetric[]>;
+
     abstract blocks(limit?: number, page?: number): Block[] | Promise<Block[]>;
 
     abstract blockByHash(hash?: string): Block | Promise<Block>;
@@ -217,10 +226,6 @@ export abstract class IQuery {
     abstract minedBlocksByAddress(address?: string, limit?: number, page?: number): Block[] | Promise<Block[]>;
 
     abstract totalNumberOfBlocks(): number | Promise<number>;
-
-    abstract blockMetricByHash(hash?: string): BlockMetric | Promise<BlockMetric>;
-
-    abstract blockMetrics(limit?: number, page?: number): BlockMetric[] | Promise<BlockMetric[]>;
 
     abstract contractByHash(hash?: string): Contract | Promise<Contract>;
 
@@ -270,7 +275,7 @@ export abstract class IQuery {
 
     abstract tx(hash: string): Transaction | Promise<Transaction>;
 
-    abstract txs(limit?: number, order?: string, fromBlock?: number): Transaction[] | Promise<Transaction[]>;
+    abstract txs(limit?: number, order?: Order, fromBlock?: number): Transaction[] | Promise<Transaction[]>;
 
     abstract txsForBlock(hash: string): Transaction[] | Promise<Transaction[]>;
 

--- a/apps/api-nestjs/src/graphql/schema.ts
+++ b/apps/api-nestjs/src/graphql/schema.ts
@@ -208,10 +208,6 @@ export abstract class IQuery {
 
     abstract totalNumberOfBlocks(): number | Promise<number>;
 
-    abstract contractByHash(hash?: string): Contract | Promise<Contract>;
-
-    abstract contractsCreatedBy(creator?: string, limit?: number, page?: number): Contract[] | Promise<Contract[]>;
-
     abstract quote(token: string, to: string): Quote | Promise<Quote>;
 
     abstract tokenExchangeRates(filter: TokenExchangeRateFilter, limit?: number, page?: number): TokenExchangeRate[] | Promise<TokenExchangeRate[]>;
@@ -221,6 +217,10 @@ export abstract class IQuery {
     abstract tokenExchangeRateBySymbol(symbol: string): TokenExchangeRate | Promise<TokenExchangeRate>;
 
     abstract tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
+
+    abstract contractByHash(hash?: string): Contract | Promise<Contract>;
+
+    abstract contractsCreatedBy(creator?: string, limit?: number, page?: number): Contract[] | Promise<Contract[]>;
 
     abstract processingMetadataById(id: string): ProcessingMetadata | Promise<ProcessingMetadata>;
 

--- a/apps/api-nestjs/src/graphql/shared.graphql
+++ b/apps/api-nestjs/src/graphql/shared.graphql
@@ -4,3 +4,8 @@ scalar Decimal
 scalar Buffer
 scalar StatisticValue
 scalar Long
+
+
+enum FilterEnum {
+  in, out, all
+}

--- a/apps/api-nestjs/src/modules/account-metadata/account-metadata.resolvers.ts
+++ b/apps/api-nestjs/src/modules/account-metadata/account-metadata.resolvers.ts
@@ -1,13 +1,14 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { AccountMetadataService } from '@app/modules/account-metadata/account-metadata.service'
 import { AccountMetadataDto } from '@app/modules/account-metadata/account-metadata.dto'
+import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 
 @Resolver('AccountMetadata')
 export class AccountMetadataResolvers {
   constructor(private readonly accountMetadataService: AccountMetadataService) {}
 
   @Query()
-  async accountMetadataByHash(@Args('hash') hash: string) {
+  async accountMetadataByHash(@Args('hash', ParseAddressPipe) hash: string) {
     const entity = await this.accountMetadataService.findAccountMetadataByHash(hash)
     return entity ? new AccountMetadataDto(entity) : null
   }

--- a/apps/api-nestjs/src/modules/balances/balance.resolvers.ts
+++ b/apps/api-nestjs/src/modules/balances/balance.resolvers.ts
@@ -1,13 +1,14 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { BalanceService } from '@app/modules/balances/balance.service'
 import { BalanceDto } from '@app/modules/balances/balance.dto'
+import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 
 @Resolver('Balance')
 export class BalanceResolvers {
   constructor(private readonly balanceService: BalanceService) {}
 
   @Query()
-  async balanceByHash(@Args('hash') hash: string) {
+  async balanceByHash(@Args('hash', ParseAddressPipe) hash: string) {
     const entity = await this.balanceService.findBalanceByHash(hash)
     return entity ? new BalanceDto(entity) : null
   }

--- a/apps/api-nestjs/src/modules/block-metrics/block-metric.resolvers.ts
+++ b/apps/api-nestjs/src/modules/block-metrics/block-metric.resolvers.ts
@@ -1,13 +1,14 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { BlockMetricService } from '@app/modules/block-metrics/block-metric.service'
 import { BlockMetricDto } from '@app/modules/block-metrics/block-metric.dto'
+import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 
 @Resolver('BlockMetric')
 export class BlockMetricResolvers {
   constructor(private readonly blockMetricService: BlockMetricService) {}
 
   @Query()
-  async blockMetricByHash(@Args('hash') hash: string) {
+  async blockMetricByHash(@Args('hash', ParseHashPipe) hash: string) {
     const entity = await this.blockMetricService.findBlockMetricByHash(hash)
     return entity ? new BlockMetricDto(entity) : null
   }

--- a/apps/api-nestjs/src/modules/block-metrics/block-metric.resolvers.ts
+++ b/apps/api-nestjs/src/modules/block-metrics/block-metric.resolvers.ts
@@ -3,6 +3,7 @@ import { BlockMetricService } from '@app/modules/block-metrics/block-metric.serv
 import { BlockMetricDto } from '@app/modules/block-metrics/block-metric.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
+import { ParsePagePipe } from '@app/shared/validation/parse-page.pipe'
 
 @Resolver('BlockMetric')
 export class BlockMetricResolvers {
@@ -15,7 +16,7 @@ export class BlockMetricResolvers {
   }
 
   @Query()
-  async blockMetrics(@Args('limit', ParseLimitPipe) limit: number, @Args('page') page: number) {
+  async blockMetrics(@Args('limit', ParseLimitPipe) limit: number, @Args('page', ParsePagePipe) page: number) {
     const entities = await this.blockMetricService.findBlockMetrics(limit, page)
     return entities.map(e => new BlockMetricDto(e))
   }

--- a/apps/api-nestjs/src/modules/block-metrics/block-metric.resolvers.ts
+++ b/apps/api-nestjs/src/modules/block-metrics/block-metric.resolvers.ts
@@ -2,6 +2,7 @@ import { Args, Query, Resolver } from '@nestjs/graphql'
 import { BlockMetricService } from '@app/modules/block-metrics/block-metric.service'
 import { BlockMetricDto } from '@app/modules/block-metrics/block-metric.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
+import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
 
 @Resolver('BlockMetric')
 export class BlockMetricResolvers {
@@ -14,7 +15,7 @@ export class BlockMetricResolvers {
   }
 
   @Query()
-  async blockMetrics(@Args('limit') limit: number, @Args('page') page: number) {
+  async blockMetrics(@Args('limit', ParseLimitPipe) limit: number, @Args('page') page: number) {
     const entities = await this.blockMetricService.findBlockMetrics(limit, page)
     return entities.map(e => new BlockMetricDto(e))
   }

--- a/apps/api-nestjs/src/modules/blocks/block.resolvers.ts
+++ b/apps/api-nestjs/src/modules/blocks/block.resolvers.ts
@@ -4,6 +4,7 @@ import { PubSub } from 'graphql-subscriptions'
 import { BlockDto } from '@app/modules/blocks/block.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
+import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
 
 const pubSub = new PubSub()
 
@@ -12,7 +13,7 @@ export class BlockResolvers {
   constructor(private readonly blockService: BlockService) {}
 
   @Query()
-  async blocks(@Args('page') page: number, @Args('limit') limit: number) {
+  async blocks(@Args('page') page: number, @Args('limit', ParseLimitPipe) limit: number) {
     const entities = await this.blockService.findBlocks(limit, page)
     return entities.map(e => new BlockDto(e))
   }
@@ -30,7 +31,11 @@ export class BlockResolvers {
   }
 
   @Query()
-  async minedBlocksByAddress(@Args('address', ParseAddressPipe) address: string, @Args('limit') limit: number, @Args('page') page: number) {
+  async minedBlocksByAddress(
+    @Args('address', ParseAddressPipe) address: string,
+    @Args('limit') limit: number,
+    @Args('page', ParseLimitPipe) page: number
+  ) {
     const entities = await this.blockService.findMinedBlocksByAddress(address, limit, page)
     return entities.map(e => new BlockDto(e))
   }

--- a/apps/api-nestjs/src/modules/blocks/block.resolvers.ts
+++ b/apps/api-nestjs/src/modules/blocks/block.resolvers.ts
@@ -3,6 +3,7 @@ import { BlockService } from '@app/modules/blocks/block.service'
 import { PubSub } from 'graphql-subscriptions'
 import { BlockDto } from '@app/modules/blocks/block.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
+import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 
 const pubSub = new PubSub()
 
@@ -29,7 +30,7 @@ export class BlockResolvers {
   }
 
   @Query()
-  async minedBlocksByAddress(@Args('address') address: string, @Args('limit') limit: number, @Args('page') page: number) {
+  async minedBlocksByAddress(@Args('address', ParseAddressPipe) address: string, @Args('limit') limit: number, @Args('page') page: number) {
     const entities = await this.blockService.findMinedBlocksByAddress(address, limit, page)
     return entities.map(e => new BlockDto(e))
   }

--- a/apps/api-nestjs/src/modules/blocks/block.resolvers.ts
+++ b/apps/api-nestjs/src/modules/blocks/block.resolvers.ts
@@ -2,6 +2,7 @@ import { Args, Query, Resolver, Subscription } from '@nestjs/graphql'
 import { BlockService } from '@app/modules/blocks/block.service'
 import { PubSub } from 'graphql-subscriptions'
 import { BlockDto } from '@app/modules/blocks/block.dto'
+import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 
 const pubSub = new PubSub()
 
@@ -16,7 +17,7 @@ export class BlockResolvers {
   }
 
   @Query()
-  async blockByHash(@Args('hash') hash: string) {
+  async blockByHash(@Args('hash', ParseHashPipe) hash: string) {
     const entity = await this.blockService.findBlockByHash(hash)
     return entity ? new BlockDto(entity) : null
   }

--- a/apps/api-nestjs/src/modules/blocks/block.resolvers.ts
+++ b/apps/api-nestjs/src/modules/blocks/block.resolvers.ts
@@ -5,6 +5,7 @@ import { BlockDto } from '@app/modules/blocks/block.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
+import { ParsePagePipe } from '@app/shared/validation/parse-page.pipe'
 
 const pubSub = new PubSub()
 
@@ -13,7 +14,7 @@ export class BlockResolvers {
   constructor(private readonly blockService: BlockService) {}
 
   @Query()
-  async blocks(@Args('page') page: number, @Args('limit', ParseLimitPipe) limit: number) {
+  async blocks(@Args('page', ParsePagePipe) page: number, @Args('limit', ParseLimitPipe) limit: number) {
     const entities = await this.blockService.findBlocks(limit, page)
     return entities.map(e => new BlockDto(e))
   }
@@ -33,8 +34,8 @@ export class BlockResolvers {
   @Query()
   async minedBlocksByAddress(
     @Args('address', ParseAddressPipe) address: string,
-    @Args('limit') limit: number,
-    @Args('page', ParseLimitPipe) page: number
+    @Args('limit', ParseLimitPipe) limit: number,
+    @Args('page', ParsePagePipe) page: number
   ) {
     const entities = await this.blockService.findMinedBlocksByAddress(address, limit, page)
     return entities.map(e => new BlockDto(e))

--- a/apps/api-nestjs/src/modules/contracts/contract.resolvers.ts
+++ b/apps/api-nestjs/src/modules/contracts/contract.resolvers.ts
@@ -3,6 +3,7 @@ import { ContractService } from '@app/modules/contracts/contract.service'
 import { ContractDto } from '@app/modules/contracts/contract.dto'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
+import { ParsePagePipe } from '@app/shared/validation/parse-page.pipe'
 
 @Resolver('Contract')
 export class ContractResolvers {
@@ -18,7 +19,7 @@ export class ContractResolvers {
   async contractsCreatedBy(
     @Args('creator', ParseAddressPipe) creator: string,
     @Args('limit', ParseLimitPipe) limit: number,
-    @Args('page') page: number
+    @Args('page', ParsePagePipe) page: number
   ) {
     const entities = await this.contractService.findContractsCreatedBy(creator, limit, page)
     return entities.map(e => new ContractDto(e))

--- a/apps/api-nestjs/src/modules/contracts/contract.resolvers.ts
+++ b/apps/api-nestjs/src/modules/contracts/contract.resolvers.ts
@@ -1,19 +1,20 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { ContractService } from '@app/modules/contracts/contract.service'
 import { ContractDto } from '@app/modules/contracts/contract.dto'
+import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 
 @Resolver('Contract')
 export class ContractResolvers {
   constructor(private readonly contractService: ContractService) {}
 
   @Query()
-  async contractByHash(@Args('hash') hash: string) {
+  async contractByHash(@Args('hash', ParseAddressPipe) hash: string) {
     const entity = await this.contractService.findContractByHash(hash)
     return entity ? new ContractDto(entity) : null
   }
 
   @Query()
-  async contractsCreatedBy(@Args('creator') creator: string, @Args('limit') limit: number, @Args('page') page: number) {
+  async contractsCreatedBy(@Args('creator', ParseAddressPipe) creator: string, @Args('limit') limit: number, @Args('page') page: number) {
     const entities = await this.contractService.findContractsCreatedBy(creator, limit, page)
     return entities.map(e => new ContractDto(e))
   }

--- a/apps/api-nestjs/src/modules/contracts/contract.resolvers.ts
+++ b/apps/api-nestjs/src/modules/contracts/contract.resolvers.ts
@@ -2,6 +2,7 @@ import { Args, Query, Resolver } from '@nestjs/graphql'
 import { ContractService } from '@app/modules/contracts/contract.service'
 import { ContractDto } from '@app/modules/contracts/contract.dto'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
+import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
 
 @Resolver('Contract')
 export class ContractResolvers {
@@ -14,7 +15,11 @@ export class ContractResolvers {
   }
 
   @Query()
-  async contractsCreatedBy(@Args('creator', ParseAddressPipe) creator: string, @Args('limit') limit: number, @Args('page') page: number) {
+  async contractsCreatedBy(
+    @Args('creator', ParseAddressPipe) creator: string,
+    @Args('limit', ParseLimitPipe) limit: number,
+    @Args('page') page: number
+  ) {
     const entities = await this.contractService.findContractsCreatedBy(creator, limit, page)
     return entities.map(e => new ContractDto(e))
   }

--- a/apps/api-nestjs/src/modules/exchanges/exchange.graphql
+++ b/apps/api-nestjs/src/modules/exchanges/exchange.graphql
@@ -1,5 +1,5 @@
 type Query {
-  quote(token: String!, to: String!): Quote
+  quote(token: ExchangeFrom!, to: ExchangeTo!): Quote
   tokenExchangeRates(filter: TokenExchangeRateFilter!, limit: Int, page: Int): [TokenExchangeRate]!
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
@@ -11,6 +11,14 @@ type Quote {
   price: String
   last_update: Decimal
   vol_24h: String
+}
+
+enum ExchangeTo {
+  USD
+}
+
+enum ExchangeFrom {
+  ETH
 }
 
 type TokenExchangeRate {

--- a/apps/api-nestjs/src/modules/exchanges/token-exchange-rate.resolvers.ts
+++ b/apps/api-nestjs/src/modules/exchanges/token-exchange-rate.resolvers.ts
@@ -1,6 +1,7 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { ExchangeService } from '@app/modules/exchanges/exchange.service'
 import { TokenExchangeRateDto } from '@app/modules/exchanges/token-exchange-rate.dto'
+import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 
 @Resolver('TokenExchangeRate')
 export class TokenExchangeRateResolvers {
@@ -29,7 +30,7 @@ export class TokenExchangeRateResolvers {
   }
 
   @Query()
-  async tokenExchangeRateByAddress(@Args('address') address: string) {
+  async tokenExchangeRateByAddress(@Args('address', ParseAddressPipe) address: string) {
     const entity = await this.exchangeService.findTokenExchangeRateByAddress(address)
     return entity ? new TokenExchangeRateDto(entity) : null
   }

--- a/apps/api-nestjs/src/modules/exchanges/token-exchange-rate.resolvers.ts
+++ b/apps/api-nestjs/src/modules/exchanges/token-exchange-rate.resolvers.ts
@@ -3,6 +3,7 @@ import { ExchangeService } from '@app/modules/exchanges/exchange.service'
 import { TokenExchangeRateDto } from '@app/modules/exchanges/token-exchange-rate.dto'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
+import { ParsePagePipe } from '@app/shared/validation/parse-page.pipe'
 
 @Resolver('TokenExchangeRate')
 export class TokenExchangeRateResolvers {
@@ -17,7 +18,7 @@ export class TokenExchangeRateResolvers {
   async tokenExchangeRates(
     @Args('filter') filter: string,
     @Args('limit', ParseLimitPipe) limit: number,
-    @Args('page') page: number
+    @Args('page', ParsePagePipe) page: number
   ) {
     const entities = await this.exchangeService.findTokenExchangeRates(filter, limit, page)
     return entities.map(e => new TokenExchangeRateDto(e))

--- a/apps/api-nestjs/src/modules/exchanges/token-exchange-rate.resolvers.ts
+++ b/apps/api-nestjs/src/modules/exchanges/token-exchange-rate.resolvers.ts
@@ -2,6 +2,7 @@ import { Args, Query, Resolver } from '@nestjs/graphql'
 import { ExchangeService } from '@app/modules/exchanges/exchange.service'
 import { TokenExchangeRateDto } from '@app/modules/exchanges/token-exchange-rate.dto'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
+import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
 
 @Resolver('TokenExchangeRate')
 export class TokenExchangeRateResolvers {
@@ -13,7 +14,11 @@ export class TokenExchangeRateResolvers {
   }
 
   @Query()
-  async tokenExchangeRates(@Args('filter') filter: string, @Args('limit') limit: number, @Args('page') page: number) {
+  async tokenExchangeRates(
+    @Args('filter') filter: string,
+    @Args('limit', ParseLimitPipe) limit: number,
+    @Args('page') page: number
+  ) {
     const entities = await this.exchangeService.findTokenExchangeRates(filter, limit, page)
     return entities.map(e => new TokenExchangeRateDto(e))
   }

--- a/apps/api-nestjs/src/modules/token-transfers/token-transfer.graphql
+++ b/apps/api-nestjs/src/modules/token-transfers/token-transfer.graphql
@@ -1,6 +1,6 @@
 type Query {
   addressTokenTransfers(address: String!, limit: Int, page: Int): [TokenTransfer]
-  addressTokenTransfersByHolder(address: String!, holder: String!, filter: String, limit: Int, page: Int): [TokenTransfer]
+  addressTokenTransfersByHolder(address: String!, holder: String!, filter: FilterEnum, limit: Int, page: Int): [TokenTransfer]
 }
 
 type TokenTransfer {

--- a/apps/api-nestjs/src/modules/token-transfers/token-transfer.resolvers.ts
+++ b/apps/api-nestjs/src/modules/token-transfers/token-transfer.resolvers.ts
@@ -3,6 +3,7 @@ import { TokenTransferService } from '@app/modules/token-transfers/token-transfe
 import { TokenExchangeRateDto } from '@app/modules/exchanges/token-exchange-rate.dto'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
+import { ParsePagePipe } from '@app/shared/validation/parse-page.pipe'
 
 @Resolver('TokenTransfer')
 export class TokenTransferResolvers {
@@ -12,7 +13,7 @@ export class TokenTransferResolvers {
   async addressTokenTransfers(
     @Args('address', ParseAddressPipe) address: string,
     @Args('limit', ParseLimitPipe) limit?: number,
-    @Args('page') page?: number
+    @Args('page', ParsePagePipe) page?: number
   ) {
     const entities = await this.tokenTransferService.findAddressTokenTransfers(address, limit, page)
     return entities.map(e => new TokenExchangeRateDto(e))
@@ -20,11 +21,11 @@ export class TokenTransferResolvers {
 
   @Query()
   async addressTokenTransfersByHolder(
-    @Args('address') address: string,
+    @Args('address', ParseAddressPipe) address: string,
     @Args('holder') holder: string,
     @Args('filter') filter?: string,
     @Args('limit', ParseLimitPipe) limit?: number,
-    @Args('page') page?: number
+    @Args('page', ParsePagePipe) page?: number
   ) {
     const entities = await this.tokenTransferService.findAddressTokenTransfersByHolder(address, holder, filter, limit, page)
     return entities.map(e => new TokenExchangeRateDto(e))

--- a/apps/api-nestjs/src/modules/token-transfers/token-transfer.resolvers.ts
+++ b/apps/api-nestjs/src/modules/token-transfers/token-transfer.resolvers.ts
@@ -1,13 +1,18 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { TokenTransferService } from '@app/modules/token-transfers/token-transfer.service'
 import { TokenExchangeRateDto } from '@app/modules/exchanges/token-exchange-rate.dto'
+import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 
 @Resolver('TokenTransfer')
 export class TokenTransferResolvers {
   constructor(private readonly tokenTransferService: TokenTransferService) {}
 
   @Query()
-  async addressTokenTransfers(@Args('address') address: string, @Args('limit') limit?: number, @Args('page') page?: number) {
+  async addressTokenTransfers(
+    @Args('address', ParseAddressPipe) address: string,
+    @Args('limit') limit?: number,
+    @Args('page') page?: number
+  ) {
     const entities = await this.tokenTransferService.findAddressTokenTransfers(address, limit, page)
     return entities.map(e => new TokenExchangeRateDto(e))
   }

--- a/apps/api-nestjs/src/modules/token-transfers/token-transfer.resolvers.ts
+++ b/apps/api-nestjs/src/modules/token-transfers/token-transfer.resolvers.ts
@@ -2,6 +2,7 @@ import { Args, Query, Resolver } from '@nestjs/graphql'
 import { TokenTransferService } from '@app/modules/token-transfers/token-transfer.service'
 import { TokenExchangeRateDto } from '@app/modules/exchanges/token-exchange-rate.dto'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
+import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
 
 @Resolver('TokenTransfer')
 export class TokenTransferResolvers {
@@ -10,7 +11,7 @@ export class TokenTransferResolvers {
   @Query()
   async addressTokenTransfers(
     @Args('address', ParseAddressPipe) address: string,
-    @Args('limit') limit?: number,
+    @Args('limit', ParseLimitPipe) limit?: number,
     @Args('page') page?: number
   ) {
     const entities = await this.tokenTransferService.findAddressTokenTransfers(address, limit, page)
@@ -22,7 +23,7 @@ export class TokenTransferResolvers {
     @Args('address') address: string,
     @Args('holder') holder: string,
     @Args('filter') filter?: string,
-    @Args('limit') limit?: number,
+    @Args('limit', ParseLimitPipe) limit?: number,
     @Args('page') page?: number
   ) {
     const entities = await this.tokenTransferService.findAddressTokenTransfersByHolder(address, holder, filter, limit, page)

--- a/apps/api-nestjs/src/modules/token-transfers/token-transfer.service.ts
+++ b/apps/api-nestjs/src/modules/token-transfers/token-transfer.service.ts
@@ -23,7 +23,7 @@ export class TokenTransferService {
   async findAddressTokenTransfersByHolder(
     address: string,
     holder: string,
-    filter?: string,
+    filter: string = 'all',
     take: number = 10,
     page: number = 0
   ): Promise<TokenTransferEntity[]> {

--- a/apps/api-nestjs/src/modules/txs/tx.graphql
+++ b/apps/api-nestjs/src/modules/txs/tx.graphql
@@ -1,6 +1,6 @@
 type Query {
   tx(hash: String!): Transaction
-  txs(limit: Int, order: String, fromBlock: Int): [Transaction]
+  txs(limit: Int, order: Order, fromBlock: Int): [Transaction]
   txsForBlock(hash: String!): [Transaction]
   txsForAddress(hash: String!, filter: FilterEnum, limit: Int, page: Int): [Transaction]
   totalNumberOfTransactions: Int
@@ -101,4 +101,8 @@ type TraceRewardActionRecord {
   author: String
   value: String
   rewardType: String
+}
+
+enum Order {
+  asc, desc
 }

--- a/apps/api-nestjs/src/modules/txs/tx.graphql
+++ b/apps/api-nestjs/src/modules/txs/tx.graphql
@@ -2,7 +2,7 @@ type Query {
   tx(hash: String!): Transaction
   txs(limit: Int, order: String, fromBlock: Int): [Transaction]
   txsForBlock(hash: String!): [Transaction]
-  txsForAddress(hash: String!, filter: String, limit: Int, page: Int): [Transaction]
+  txsForAddress(hash: String!, filter: FilterEnum, limit: Int, page: Int): [Transaction]
   totalNumberOfTransactions: Int
 }
 

--- a/apps/api-nestjs/src/modules/txs/tx.resolvers.ts
+++ b/apps/api-nestjs/src/modules/txs/tx.resolvers.ts
@@ -4,6 +4,7 @@ import { TxDto } from '@app/modules/txs/tx.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
+import { ParsePagePipe } from '@app/shared/validation/parse-page.pipe'
 
 @Resolver('Transaction')
 export class TxResolvers {
@@ -16,7 +17,11 @@ export class TxResolvers {
   }
 
   @Query()
-  async txs(@Args('limit') limit?: number, @Args('order') order?: string, @Args('fromBlock') fromBlock?: number) {
+  async txs(
+    @Args('limit', ParseLimitPipe) limit?: number,
+    @Args('order') order?: string,
+    @Args('fromBlock') fromBlock?: number
+  ) {
     const entities = await this.txService.findTxs(limit, order, fromBlock)
     return entities.map(e => new TxDto(e))
   }
@@ -32,7 +37,7 @@ export class TxResolvers {
     @Args('hash', ParseAddressPipe) hash: string,
     @Args('filter') filter?: string,
     @Args('limit', ParseLimitPipe) limit?: number,
-    @Args('page') page?: number
+    @Args('page', ParsePagePipe) page?: number
   ) {
     const entities = await this.txService.findTxsForAddress(hash, filter, limit, page)
     return entities.map(e => new TxDto(e))

--- a/apps/api-nestjs/src/modules/txs/tx.resolvers.ts
+++ b/apps/api-nestjs/src/modules/txs/tx.resolvers.ts
@@ -1,13 +1,14 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { TxService } from '@app/modules/txs/tx.service'
 import { TxDto } from '@app/modules/txs/tx.dto'
+import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 
 @Resolver('Transaction')
 export class TxResolvers {
   constructor(private readonly txService: TxService) {}
 
   @Query()
-  async tx(@Args('hash') hash: string) {
+  async tx(@Args('hash', ParseHashPipe) hash: string) {
     const entity = await this.txService.findTx(hash)
     return entity ? new TxDto(entity) : null
   }
@@ -19,7 +20,7 @@ export class TxResolvers {
   }
 
   @Query()
-  async txsForBlock(@Args('hash') hash: string) {
+  async txsForBlock(@Args('hash', ParseHashPipe) hash: string) {
     const entities = await this.txService.findTxsForBlock(hash)
     return entities.map(e => new TxDto(e))
   }

--- a/apps/api-nestjs/src/modules/txs/tx.resolvers.ts
+++ b/apps/api-nestjs/src/modules/txs/tx.resolvers.ts
@@ -2,6 +2,7 @@ import { Args, Query, Resolver } from '@nestjs/graphql'
 import { TxService } from '@app/modules/txs/tx.service'
 import { TxDto } from '@app/modules/txs/tx.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
+import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 
 @Resolver('Transaction')
 export class TxResolvers {
@@ -26,7 +27,7 @@ export class TxResolvers {
   }
 
   @Query()
-  async txsForAddress(@Args('hash') hash: string, @Args('filter') filter?: string, @Args('limit') limit?: number, @Args('page') page?: number) {
+  async txsForAddress(@Args('hash', ParseAddressPipe) hash: string, @Args('filter') filter?: string, @Args('limit') limit?: number, @Args('page') page?: number) {
     const entities = await this.txService.findTxsForAddress(hash, filter, limit, page)
     return entities.map(e => new TxDto(e))
   }

--- a/apps/api-nestjs/src/modules/txs/tx.resolvers.ts
+++ b/apps/api-nestjs/src/modules/txs/tx.resolvers.ts
@@ -3,6 +3,7 @@ import { TxService } from '@app/modules/txs/tx.service'
 import { TxDto } from '@app/modules/txs/tx.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
+import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
 
 @Resolver('Transaction')
 export class TxResolvers {
@@ -27,7 +28,12 @@ export class TxResolvers {
   }
 
   @Query()
-  async txsForAddress(@Args('hash', ParseAddressPipe) hash: string, @Args('filter') filter?: string, @Args('limit') limit?: number, @Args('page') page?: number) {
+  async txsForAddress(
+    @Args('hash', ParseAddressPipe) hash: string,
+    @Args('filter') filter?: string,
+    @Args('limit', ParseLimitPipe) limit?: number,
+    @Args('page') page?: number
+  ) {
     const entities = await this.txService.findTxsForAddress(hash, filter, limit, page)
     return entities.map(e => new TxDto(e))
   }

--- a/apps/api-nestjs/src/modules/uncles/uncle.resolvers.ts
+++ b/apps/api-nestjs/src/modules/uncles/uncle.resolvers.ts
@@ -1,13 +1,14 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { UncleService } from '@app/modules/uncles/uncle.service'
 import { UncleDto } from '@app/modules/uncles/uncle.dto'
+import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 
 @Resolver('Uncle')
 export class UncleResolvers {
   constructor(private readonly uncleService: UncleService) {}
 
   @Query()
-  async uncleByHash(@Args('hash') hash: string) {
+  async uncleByHash(@Args('hash', ParseHashPipe) hash: string) {
     const entity = await this.uncleService.findUncleByHash(hash)
     return entity ? new UncleDto(entity) : null
   }

--- a/apps/api-nestjs/src/modules/uncles/uncle.resolvers.ts
+++ b/apps/api-nestjs/src/modules/uncles/uncle.resolvers.ts
@@ -3,6 +3,7 @@ import { UncleService } from '@app/modules/uncles/uncle.service'
 import { UncleDto } from '@app/modules/uncles/uncle.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
+import { ParsePagePipe } from '@app/shared/validation/parse-page.pipe'
 
 @Resolver('Uncle')
 export class UncleResolvers {
@@ -17,7 +18,7 @@ export class UncleResolvers {
   @Query()
   async uncles(
     @Args('limit', ParseLimitPipe) limit?: number,
-    @Args('page') page?: number,
+    @Args('page', ParsePagePipe) page?: number,
     @Args('fromUncle') fromUncle?: number
   ) {
     const entities = await this.uncleService.findUncles(limit, page, fromUncle)

--- a/apps/api-nestjs/src/modules/uncles/uncle.resolvers.ts
+++ b/apps/api-nestjs/src/modules/uncles/uncle.resolvers.ts
@@ -2,6 +2,7 @@ import { Args, Query, Resolver } from '@nestjs/graphql'
 import { UncleService } from '@app/modules/uncles/uncle.service'
 import { UncleDto } from '@app/modules/uncles/uncle.dto'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
+import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
 
 @Resolver('Uncle')
 export class UncleResolvers {
@@ -14,7 +15,11 @@ export class UncleResolvers {
   }
 
   @Query()
-  async uncles(@Args('limit') limit?: number, @Args('page') page?: number, @Args('fromUncle') fromUncle?: number) {
+  async uncles(
+    @Args('limit', ParseLimitPipe) limit?: number,
+    @Args('page') page?: number,
+    @Args('fromUncle') fromUncle?: number
+  ) {
     const entities = await this.uncleService.findUncles(limit, page, fromUncle)
     return entities.map(e => new UncleDto(e))
   }

--- a/apps/api-nestjs/src/shared/duration.service.ts
+++ b/apps/api-nestjs/src/shared/duration.service.ts
@@ -15,7 +15,6 @@ export enum Duration {
 
 @Injectable()
 export class DurationService {
-
   public durationToDates(duration: Duration): StartEndInterface {
     const to = new Date()
     // Always at the end of the day

--- a/apps/api-nestjs/src/shared/eth.service.ts
+++ b/apps/api-nestjs/src/shared/eth.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common'
 
+const MAX_PAGE_SIZE = 100
+
 @Injectable()
 export class EthService {
+
   isValidAddress(address: string): boolean {
     return /^(0x)?([0-9a-fA-F]{40})$/.test(address)
   }
@@ -20,6 +23,10 @@ export class EthService {
 
   removePrefix(hash: string): string {
     return hash.startsWith('0x') ? hash.replace('0x', '') : hash
+  }
+
+  isValidPageSize(limit): boolean {
+    return limit <= MAX_PAGE_SIZE
   }
 
 }

--- a/apps/api-nestjs/src/shared/eth.service.ts
+++ b/apps/api-nestjs/src/shared/eth.service.ts
@@ -24,7 +24,11 @@ export class EthService {
     return hash.startsWith('0x') ? hash.replace('0x', '') : hash
   }
 
-  isValidPageSize(limit: number): boolean {
-    return limit <= MAX_PAGE_SIZE
+  isValidPageSize(page: number): boolean {
+    return page >= 0
+  }
+
+  isValidLimitSize(limit: number): boolean {
+    return limit >= 1 && limit <= MAX_PAGE_SIZE
   }
 }

--- a/apps/api-nestjs/src/shared/eth.service.ts
+++ b/apps/api-nestjs/src/shared/eth.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common'
 @Injectable()
 export class EthService {
   isValidAddress(address: string): boolean {
-    return /^0x[0-9a-fA-F]{40}$/.test(address)
+    return /^(0x)?([0-9a-fA-F]{40})$/.test(address)
   }
 
   isValidHash(hash: string): boolean {

--- a/apps/api-nestjs/src/shared/eth.service.ts
+++ b/apps/api-nestjs/src/shared/eth.service.ts
@@ -4,7 +4,6 @@ const MAX_PAGE_SIZE = 100
 
 @Injectable()
 export class EthService {
-
   isValidAddress(address: string): boolean {
     return /^(0x)?([0-9a-fA-F]{40})$/.test(address)
   }
@@ -25,8 +24,7 @@ export class EthService {
     return hash.startsWith('0x') ? hash.replace('0x', '') : hash
   }
 
-  isValidPageSize(limit): boolean {
+  isValidPageSize(limit: number): boolean {
     return limit <= MAX_PAGE_SIZE
   }
-
 }

--- a/apps/api-nestjs/src/shared/shared.module.ts
+++ b/apps/api-nestjs/src/shared/shared.module.ts
@@ -4,10 +4,11 @@ import { DurationService } from '@app/shared/duration.service'
 import { EthService } from '@app/shared/eth.service'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
+import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
 
 @Global()
 @Module({
-  providers: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe],
-  exports: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe]
+  providers: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe, ParseLimitPipe],
+  exports: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe, ParseLimitPipe]
 })
 export class SharedModule {}

--- a/apps/api-nestjs/src/shared/shared.module.ts
+++ b/apps/api-nestjs/src/shared/shared.module.ts
@@ -2,10 +2,11 @@ import { Global, Module } from '@nestjs/common'
 import { ConfigService } from '@app/shared/config.service'
 import { DurationService } from '@app/shared/duration.service'
 import { EthService } from '@app/shared/eth.service'
+import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 
 @Global()
 @Module({
-  providers: [ConfigService, DurationService, EthService],
-  exports: [ConfigService, DurationService, EthService]
+  providers: [ConfigService, DurationService, EthService, ParseHashPipe],
+  exports: [ConfigService, DurationService, EthService, ParseHashPipe]
 })
 export class SharedModule {}

--- a/apps/api-nestjs/src/shared/shared.module.ts
+++ b/apps/api-nestjs/src/shared/shared.module.ts
@@ -5,10 +5,11 @@ import { EthService } from '@app/shared/eth.service'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
 import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 import { ParseLimitPipe } from '@app/shared/validation/parse-limit.pipe'
+import { ParsePagePipe } from '@app/shared/validation/parse-page.pipe'
 
 @Global()
 @Module({
-  providers: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe, ParseLimitPipe],
-  exports: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe, ParseLimitPipe]
+  providers: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe, ParseLimitPipe, ParsePagePipe],
+  exports: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe, ParseLimitPipe, ParsePagePipe]
 })
 export class SharedModule {}

--- a/apps/api-nestjs/src/shared/shared.module.ts
+++ b/apps/api-nestjs/src/shared/shared.module.ts
@@ -3,10 +3,11 @@ import { ConfigService } from '@app/shared/config.service'
 import { DurationService } from '@app/shared/duration.service'
 import { EthService } from '@app/shared/eth.service'
 import { ParseHashPipe } from '@app/shared/validation/parse-hash.pipe'
+import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 
 @Global()
 @Module({
-  providers: [ConfigService, DurationService, EthService, ParseHashPipe],
-  exports: [ConfigService, DurationService, EthService, ParseHashPipe]
+  providers: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe],
+  exports: [ConfigService, DurationService, EthService, ParseHashPipe, ParseAddressPipe]
 })
 export class SharedModule {}

--- a/apps/api-nestjs/src/shared/validation/parse-address.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-address.pipe.ts
@@ -2,11 +2,11 @@ import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from
 import { EthService } from '@app/shared/eth.service'
 
 @Injectable()
-export class ParseAddressPipe implements PipeTransform<String, String> {
+export class ParseAddressPipe implements PipeTransform<string, string> {
 
   constructor(private readonly ethService: EthService){}
 
-  transform(value: string, metadata: ArgumentMetadata): String {
+  transform(value: string, metadata: ArgumentMetadata): string {
 
     if (!this.ethService.isValidAddress(value)) {
       throw new BadRequestException('Invalid address hash');

--- a/apps/api-nestjs/src/shared/validation/parse-address.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-address.pipe.ts
@@ -3,15 +3,12 @@ import { EthService } from '@app/shared/eth.service'
 
 @Injectable()
 export class ParseAddressPipe implements PipeTransform<string, string> {
-
-  constructor(private readonly ethService: EthService){}
+  constructor(private readonly ethService: EthService) {}
 
   transform(value: string, metadata: ArgumentMetadata): string {
-
     if (!this.ethService.isValidAddress(value)) {
-      throw new BadRequestException('Invalid address hash');
+      throw new BadRequestException('Invalid address hash')
     }
-    return value.replace('0x', '');
+    return value.replace('0x', '')
   }
-
 }

--- a/apps/api-nestjs/src/shared/validation/parse-address.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-address.pipe.ts
@@ -1,0 +1,17 @@
+import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from '@nestjs/common'
+import { EthService } from '@app/shared/eth.service'
+
+@Injectable()
+export class ParseAddressPipe implements PipeTransform<String, String> {
+
+  constructor(private readonly ethService: EthService){}
+
+  transform(value: string, metadata: ArgumentMetadata): String {
+
+    if (!this.ethService.isValidAddress(value)) {
+      throw new BadRequestException('Invalid address hash');
+    }
+    return value.replace('0x', '');
+  }
+
+}

--- a/apps/api-nestjs/src/shared/validation/parse-hash.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-hash.pipe.ts
@@ -3,15 +3,12 @@ import { EthService } from '@app/shared/eth.service'
 
 @Injectable()
 export class ParseHashPipe implements PipeTransform<string, string> {
-
-  constructor(private readonly ethService: EthService){}
+  constructor(private readonly ethService: EthService) {}
 
   transform(value: string, metadata: ArgumentMetadata): string {
-
     if (!this.ethService.isValidHash(value)) {
-      throw new BadRequestException('Invalid hash');
+      throw new BadRequestException('Invalid hash')
     }
-    return value.replace('0x', '');
+    return value.replace('0x', '')
   }
-
 }

--- a/apps/api-nestjs/src/shared/validation/parse-hash.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-hash.pipe.ts
@@ -2,11 +2,11 @@ import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from
 import { EthService } from '@app/shared/eth.service'
 
 @Injectable()
-export class ParseHashPipe implements PipeTransform<String, String> {
+export class ParseHashPipe implements PipeTransform<string, string> {
 
   constructor(private readonly ethService: EthService){}
 
-  transform(value: string, metadata: ArgumentMetadata): String {
+  transform(value: string, metadata: ArgumentMetadata): string {
 
     if (!this.ethService.isValidHash(value)) {
       throw new BadRequestException('Invalid hash');

--- a/apps/api-nestjs/src/shared/validation/parse-hash.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-hash.pipe.ts
@@ -1,0 +1,17 @@
+import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from '@nestjs/common'
+import { EthService } from '@app/shared/eth.service'
+
+@Injectable()
+export class ParseHashPipe implements PipeTransform<String, String> {
+
+  constructor(private readonly ethService: EthService){}
+
+  transform(value: string, metadata: ArgumentMetadata): String {
+
+    if (!this.ethService.isValidHash(value)) {
+      throw new BadRequestException('Invalid hash');
+    }
+    return value.replace('0x', '');
+  }
+
+}

--- a/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
@@ -3,11 +3,9 @@ import { EthService } from '@app/shared/eth.service'
 
 @Injectable()
 export class ParseLimitPipe implements PipeTransform<number, number> {
-
-  constructor(private readonly ethService: EthService){}
+  constructor(private readonly ethService: EthService) {}
 
   transform(value: number, metadata: ArgumentMetadata): number {
-
     if (!value) return 10
 
     if (!this.ethService.isValidPageSize(value)) {
@@ -15,5 +13,4 @@ export class ParseLimitPipe implements PipeTransform<number, number> {
     }
     return value
   }
-
 }

--- a/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
@@ -1,0 +1,17 @@
+import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from '@nestjs/common'
+import { EthService } from '@app/shared/eth.service'
+
+@Injectable()
+export class ParseLimitPipe implements PipeTransform<String, String> {
+
+  constructor(private readonly ethService: EthService){}
+
+  transform(value: string, metadata: ArgumentMetadata): String {
+
+    if (!this.ethService.isValidPageSize(value)) {
+      throw new BadRequestException('Invalid limit. Exceeds max page size.')
+    }
+    return value
+  }
+
+}

--- a/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
@@ -11,6 +11,7 @@ export class ParseLimitPipe implements PipeTransform<number, number> {
     if (!this.ethService.isValidPageSize(value)) {
       throw new BadRequestException('Invalid limit. Exceeds max page size.')
     }
+
     return value
   }
 }

--- a/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
@@ -2,11 +2,13 @@ import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from
 import { EthService } from '@app/shared/eth.service'
 
 @Injectable()
-export class ParseLimitPipe implements PipeTransform<String, String> {
+export class ParseLimitPipe implements PipeTransform<number, number> {
 
   constructor(private readonly ethService: EthService){}
 
-  transform(value: string, metadata: ArgumentMetadata): String {
+  transform(value: number, metadata: ArgumentMetadata): number {
+
+    if (!value) return 10
 
     if (!this.ethService.isValidPageSize(value)) {
       throw new BadRequestException('Invalid limit. Exceeds max page size.')

--- a/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-limit.pipe.ts
@@ -8,8 +8,8 @@ export class ParseLimitPipe implements PipeTransform<number, number> {
   transform(value: number, metadata: ArgumentMetadata): number {
     if (!value) return 10
 
-    if (!this.ethService.isValidPageSize(value)) {
-      throw new BadRequestException('Invalid limit. Exceeds max page size.')
+    if (!this.ethService.isValidLimitSize(value)) {
+      throw new BadRequestException('Invalid limit. Must be greater than 0 and less than 100.')
     }
 
     return value

--- a/apps/api-nestjs/src/shared/validation/parse-page.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-page.pipe.ts
@@ -1,13 +1,14 @@
 import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from '@nestjs/common'
+import { EthService } from '@app/shared/eth.service'
 
 @Injectable()
 export class ParsePagePipe implements PipeTransform<number, number> {
-  constructor() {}
+  constructor(private readonly ethService: EthService) {}
 
   transform(value: number, metadata: ArgumentMetadata): number {
     if (!value) return 0
 
-    if (value < 0) {
+    if (!this.ethService.isValidPageSize(value)) {
       throw new BadRequestException('Invalid page. Must not be negative.')
     }
 

--- a/apps/api-nestjs/src/shared/validation/parse-page.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-page.pipe.ts
@@ -10,6 +10,7 @@ export class ParsePagePipe implements PipeTransform<number, number> {
     if (value < 0) {
       throw new BadRequestException('Invalid page. Must not be negative.')
     }
+
     return value
   }
 }

--- a/apps/api-nestjs/src/shared/validation/parse-page.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-page.pipe.ts
@@ -1,0 +1,18 @@
+import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from '@nestjs/common'
+
+@Injectable()
+export class ParsePagePipe implements PipeTransform<number, number> {
+
+  constructor(){}
+
+  transform(value: number, metadata: ArgumentMetadata): number {
+
+    if (!value) return 0
+
+    if (value < 0) {
+      throw new BadRequestException('Invalid page. Must not be negative.')
+    }
+    return value
+  }
+
+}

--- a/apps/api-nestjs/src/shared/validation/parse-page.pipe.ts
+++ b/apps/api-nestjs/src/shared/validation/parse-page.pipe.ts
@@ -2,11 +2,9 @@ import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from
 
 @Injectable()
 export class ParsePagePipe implements PipeTransform<number, number> {
-
-  constructor(){}
+  constructor() {}
 
   transform(value: number, metadata: ArgumentMetadata): number {
-
     if (!value) return 0
 
     if (value < 0) {
@@ -14,5 +12,4 @@ export class ParsePagePipe implements PipeTransform<number, number> {
     }
     return value
   }
-
 }


### PR DESCRIPTION
I've added GraphQL enums to enforce where string params must be within a given range of options and NestJS validation pipes for other use cases, such as defaulting values and validating hashes.