### PR TITLE
Bugfix: dealing with large USD values in table address tokens row

### DIFF
--- a/apps/api/src/shared/config.service.ts
+++ b/apps/api/src/shared/config.service.ts
@@ -91,7 +91,7 @@ const schema = {
     max: {
       doc: 'Express Rate Limit max requests per window(ms)',
       env: 'EXPRESS_RATE_LIMIT_MAX',
-      default: 100,
+      default: 1000,
     },
   },
 }

--- a/apps/api/src/shared/config.service.ts
+++ b/apps/api/src/shared/config.service.ts
@@ -91,7 +91,7 @@ const schema = {
     max: {
       doc: 'Express Rate Limit max requests per window(ms)',
       env: 'EXPRESS_RATE_LIMIT_MAX',
-      default: 1000,
+      default: 100,
     },
   },
 }

--- a/apps/explorer/src/core/components/mixins/mixin-number-string-concat.ts
+++ b/apps/explorer/src/core/components/mixins/mixin-number-string-concat.ts
@@ -27,6 +27,16 @@ export class StringConcatMixin extends Vue {
       .toString()
   }
 
+  getRoundNumberUnformatted(newNumber): string {
+    let round = 7
+    if (newNumber > 1) {
+      round = 2
+    }
+    return new BN(newNumber)
+      .dp(round)
+      .toString()
+  }
+
   isShortValue(rawStr = ''): boolean {
     return rawStr.length < 10
   }

--- a/apps/explorer/src/core/components/mixins/mixin-number-string-concat.ts
+++ b/apps/explorer/src/core/components/mixins/mixin-number-string-concat.ts
@@ -32,9 +32,7 @@ export class StringConcatMixin extends Vue {
     if (newNumber > 1) {
       round = 2
     }
-    return new BN(newNumber)
-      .dp(round)
-      .toString()
+    return new BN(newNumber).dp(round).toString()
   }
 
   isShortValue(rawStr = ''): boolean {

--- a/apps/explorer/src/modules/addresses/components/TableAddressTokensRow.vue
+++ b/apps/explorer/src/modules/addresses/components/TableAddressTokensRow.vue
@@ -12,18 +12,18 @@
       </v-flex>
       <v-flex hidden-xs-only sm3>
         <p class="info--text font-weight-thin mb-0">
-          <v-tooltip v-if="!isShortValue(getRoundNumber(balance(token.balance, token.decimals) * token.currentPrice), 5)" bottom>
+          <v-tooltip v-if="!isShortValue(getRoundNumberUnformatted(balance(token.balance, token.decimals) * token.currentPrice), 5)" bottom>
             <template #activator="data">
               <v-icon v-on="data.on" small class="info--text text-xs-center">fa fa-question-circle</v-icon>
             </template>
             <span
-              >${{ getShortValue(getRoundNumber(balance(token.balance, token.decimals) * token.currentPrice), 5) }} (@ ${{
+              >${{ getShortValue(getRoundNumberUnformatted(balance(token.balance, token.decimals) * token.currentPrice), 5) }} (@ ${{
                 getRoundNumber(token.currentPrice)
               }}
               per {{ token.symbol }})</span
             >
           </v-tooltip>
-          {{ getShortValue(getRoundNumber(balance(token.balance, token.decimals) * token.currentPrice)) }} (@ ${{ getRoundNumber(token.currentPrice) }} per
+          {{ getShortValue(getRoundNumberUnformatted(balance(token.balance, token.decimals) * token.currentPrice)) }} (@ ${{ getRoundNumber(token.currentPrice) }} per
           {{ token.symbol }})
         </p>
       </v-flex>

--- a/apps/explorer/src/modules/addresses/components/TableAddressTokensRow.vue
+++ b/apps/explorer/src/modules/addresses/components/TableAddressTokensRow.vue
@@ -23,8 +23,10 @@
               per {{ token.symbol }})</span
             >
           </v-tooltip>
-          {{ getShortValue(getRoundNumberUnformatted(balance(token.balance, token.decimals) * token.currentPrice)) }} (@ ${{ getRoundNumber(token.currentPrice) }} per
-          {{ token.symbol }})
+          {{ getShortValue(getRoundNumberUnformatted(balance(token.balance, token.decimals) * token.currentPrice)) }} (@ ${{
+            getRoundNumber(token.currentPrice)
+          }}
+          per {{ token.symbol }})
         </p>
       </v-flex>
     </v-layout>


### PR DESCRIPTION
When large numbers (>1000) were being converted to "short" values in TableAddressTokensRow, they were returned as NaN because getRoundNumber() helper returns a string formatted with commas. I added a new helper method (getRoundNumberUnformatted()) to return a string which can be properly processed by getShortValue() method and replaced instances of getRoundNumber() with it when dealing with USD values in this component.