### PR TITLE
Bugfix: uncles dialog in BlockDetailsTitle

### DIFF
--- a/apps/explorer/src/modules/blocks/components/BlockDetailsTitle.vue
+++ b/apps/explorer/src/modules/blocks/components/BlockDetailsTitle.vue
@@ -24,7 +24,7 @@
                   <v-layout row justify-start align-center fill-height>
                     <v-card-title class="info--text pr-0 pl-0">{{ $t('common.hash') }}:</v-card-title>
                     <v-card-text class="text-truncate font-mono">
-                      <router-link :to="'/uncle/' + uncles[index]">{{ uncles[index] }}</router-link>
+                      <router-link :to="'/uncle/' + uncle">{{ uncle }}</router-link>
                     </v-card-text>
                   </v-layout>
                 </v-list-tile>
@@ -56,8 +56,15 @@ export default class BlockDetailsTitle extends Vue {
 
   @Prop(String) nextBlock!: string
   @Prop(String) prevBlock!: string
-  @Prop(Boolean) mined!: boolean
   @Prop(Array) uncles!: string[]
+
+  /*
+  ===================================================================================
+    Initial Data
+  ===================================================================================
+  */
+
+  dialog = true
 
   /*
   ===================================================================================
@@ -70,7 +77,7 @@ export default class BlockDetailsTitle extends Vue {
   }
 
   get hasUncles(): boolean {
-    return this.mined && this.uncles != null && this.uncles.length > 0
+    return !!this.uncles && this.uncles.length > 0
   }
 }
 </script>

--- a/apps/explorer/src/modules/blocks/components/BlockDetailsTitle.vue
+++ b/apps/explorer/src/modules/blocks/components/BlockDetailsTitle.vue
@@ -12,10 +12,12 @@
         <v-layout row wrap align-center justify-start pl-0>
           <v-card-title class="title font-weight-bold">{{ title }}</v-card-title>
           <v-dialog v-if="hasUncles" v-model="dialog" max-width="700">
-            <v-btn round outline slot="activator" color="primary" class="text-capitalize" small>
-              {{ $tc('uncle.name', 2) }}
-              <v-icon right>fa fa-angle-right</v-icon>
-            </v-btn>
+            <template v-slot:activator="{ on }">
+              <v-btn round outline slot="activator" color="primary" class="text-capitalize"  v-on="on" small>
+                {{ $tc('uncle.name', 2) }}
+                <v-icon right>fa fa-angle-right</v-icon>
+              </v-btn>
+            </template>
             <v-card>
               <v-card-title class="title font-weight-bold">{{ $t('uncle.name', 2) }}:</v-card-title>
               <v-divider class="lineGrey"></v-divider>
@@ -64,7 +66,7 @@ export default class BlockDetailsTitle extends Vue {
   ===================================================================================
   */
 
-  dialog = true
+  dialog = false
 
   /*
   ===================================================================================

--- a/apps/explorer/src/modules/blocks/pages/PageDetailsBlock.vue
+++ b/apps/explorer/src/modules/blocks/pages/PageDetailsBlock.vue
@@ -10,7 +10,7 @@
       <v-flex xs12>
         <app-details-list :details="blockDetails" :is-loading="isLoading" class="mb-4" :error="error" :max-items="8">
           <template v-slot:title>
-            <block-details-title :next-block="nextBlock" :prev-block="previousBlock" :uncles="blockInfo.uncles" />
+            <block-details-title :next-block="nextBlock" :prev-block="previousBlock" :uncles="blockInfo.uncles.map(u => u.getHash())" />
             <v-divider class="lineGrey" />
           </template>
         </app-details-list>


### PR DESCRIPTION
I removed "mined" prop passed to BlockDetailsTitle, ensured "uncles" prop passed as a string array as specified in BlockDetailsTitle and correctly set button as dialog activator.