### PR TITLE
fix(processing): handling metadata read errors for bad contracts

### DIFF
--- a/apps/processing/kafka-streams/src/main/kotlin/com/ethvm/kafka/streams/processors/ContractMetadataProcessor.kt
+++ b/apps/processing/kafka-streams/src/main/kotlin/com/ethvm/kafka/streams/processors/ContractMetadataProcessor.kt
@@ -107,7 +107,7 @@ class ContractMetadataProcessor : AbstractKafkaProcessor() {
         when (ex) {
           null -> result
           else -> {
-            logger.warn { "Failed to fetch string. Contract address = $contractAddress, method = $method, error = ${ex.message}"}
+            logger.warn { "Failed to fetch string. Contract address = $contractAddress, method = $method, error = ${ex.message}" }
             null
           }
         }
@@ -129,7 +129,7 @@ class ContractMetadataProcessor : AbstractKafkaProcessor() {
         when (ex) {
           null -> result
           else -> {
-            logger.warn { "Failed to fetch decimals. Contract address = $contractAddress, error = ${ex.message}"}
+            logger.warn { "Failed to fetch decimals. Contract address = $contractAddress, error = ${ex.message}" }
             null
           }
         }
@@ -151,7 +151,7 @@ class ContractMetadataProcessor : AbstractKafkaProcessor() {
         when (ex) {
           null -> result
           else -> {
-            logger.warn { "Failed to fetch total supply. Contract address = $contractAddress, error = ${ex.message}"}
+            logger.warn { "Failed to fetch total supply. Contract address = $contractAddress, error = ${ex.message}" }
             null
           }
         }

--- a/apps/processing/kafka-streams/src/main/kotlin/com/ethvm/kafka/streams/processors/ContractMetadataProcessor.kt
+++ b/apps/processing/kafka-streams/src/main/kotlin/com/ethvm/kafka/streams/processors/ContractMetadataProcessor.kt
@@ -103,6 +103,14 @@ class ContractMetadataProcessor : AbstractKafkaProcessor() {
       .thenApply { call ->
         val output = FunctionReturnDecoder.decode(call.value, function.outputParameters)
         output.firstOrNull()?.value as String?
+      }.handle { result, ex ->
+        when (ex) {
+          null -> result
+          else -> {
+            logger.warn { "Failed to fetch string. Contract address = $contractAddress, method = $method, error = ${ex.message}"}
+            null
+          }
+        }
       }
   }
 
@@ -117,6 +125,15 @@ class ContractMetadataProcessor : AbstractKafkaProcessor() {
         val output = FunctionReturnDecoder.decode(call.value, function.outputParameters)
         output.firstOrNull()?.value as BigInteger?
       }
+      .handle { result, ex ->
+        when (ex) {
+          null -> result
+          else -> {
+            logger.warn { "Failed to fetch decimals. Contract address = $contractAddress, error = ${ex.message}"}
+            null
+          }
+        }
+      }
   }
 
   private fun fetchTotalSupply(contractAddress: String): CompletableFuture<BigInteger?> {
@@ -129,6 +146,15 @@ class ContractMetadataProcessor : AbstractKafkaProcessor() {
       .thenApply { call ->
         val output = FunctionReturnDecoder.decode(call.value, function.outputParameters)
         output.firstOrNull()?.value as BigInteger?
+      }
+      .handle { result, ex ->
+        when (ex) {
+          null -> result
+          else -> {
+            logger.warn { "Failed to fetch total supply. Contract address = $contractAddress, error = ${ex.message}"}
+            null
+          }
+        }
       }
   }
 }


### PR DESCRIPTION
When reading the symbols and decimals fields from some contracts the values are badly formed: e.g. 0x00000000000000000.... which gets mis-interpreted by web3. For now I'm handling the error and setting the value to null, logging a warning as well. These values are nonsense anyway.