### PR TITLE
Pr/#461 - tokenExchangeRates and tokensMetadata edits

### DIFF
--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -108,7 +108,7 @@ export class TokenService {
     return this.coinExchangeRateRepository.findOne(findOptions)
   }
 
-  async findTokenExchangeRates(sort: string, take: number = 10, page: number = 0): Promise<TokenExchangeRateEntity[]> {
+  async findTokenExchangeRates(sort: string, take: number = 10, page: number = 0, symbols: string[] = []): Promise<TokenExchangeRateEntity[]> {
     const skip = take * page
     let order
     switch (sort) {
@@ -135,7 +135,14 @@ export class TokenService {
         order = { marketCapRank: 1 }
         break
     }
-    return this.tokenExchangeRateRepository.find({ order, skip, take })
+    const where = symbols.length > 0 ? { symbol: Any(symbols) } : {}
+    const findOptions: FindManyOptions = {
+      where,
+      order,
+      take,
+      skip,
+    }
+    return this.tokenExchangeRateRepository.find(findOptions)
   }
 
   async countTokenExchangeRates(): Promise<number> {
@@ -168,9 +175,10 @@ export class TokenService {
     return numErc20Tokens + numErc721Tokens
   }
 
-  async findTokensMetadata(symbols: string[]): Promise<TokenMetadataDto[]> {
+  async findTokensMetadata(symbols: string[] = []): Promise<TokenMetadataDto[]> {
+    const where = symbols.length > 0 ? { symbol: Any(symbols) } : {}
     const findOptions = {
-      where: { symbol: Any(symbols) },
+      where,
       relations: ['contractMetadata'],
     }
     const erc20Tokens = await this.erc20MetadataRepository.find(findOptions)

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -244,7 +244,7 @@ export abstract class IQuery {
 
     abstract coinExchangeRate(pair: ExchangeRatePair): CoinExchangeRate | Promise<CoinExchangeRate>;
 
-    abstract tokenExchangeRates(filter: TokenExchangeRateFilter, limit?: number, page?: number, symbols?: string[]): TokenExchangeRate[] | Promise<TokenExchangeRate[]>;
+    abstract tokenExchangeRates(filter?: TokenExchangeRateFilter, limit?: number, page?: number, symbols?: string[]): TokenExchangeRate[] | Promise<TokenExchangeRate[]>;
 
     abstract totalNumTokenExchangeRates(): number | Promise<number>;
 

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -244,7 +244,7 @@ export abstract class IQuery {
 
     abstract coinExchangeRate(pair: ExchangeRatePair): CoinExchangeRate | Promise<CoinExchangeRate>;
 
-    abstract tokenExchangeRates(filter: TokenExchangeRateFilter, limit?: number, page?: number): TokenExchangeRate[] | Promise<TokenExchangeRate[]>;
+    abstract tokenExchangeRates(filter: TokenExchangeRateFilter, limit?: number, page?: number, symbols?: string[]): TokenExchangeRate[] | Promise<TokenExchangeRate[]>;
 
     abstract totalNumTokenExchangeRates(): number | Promise<number>;
 

--- a/apps/api/src/graphql/tokens/args/token-exchange-rates.args.ts
+++ b/apps/api/src/graphql/tokens/args/token-exchange-rates.args.ts
@@ -1,8 +1,7 @@
 import { ArgsType, Field } from 'type-graphql'
 
 @ArgsType()
-export class TokensMetadataArgs {
+export class TokenExchangeRatesArgs {
   @Field(type => [String])
   symbols = []
-
 }

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -4,7 +4,7 @@ type Query {
   addressAllTokensOwned(address: String!): [Token]!
   addressAmountTokensOwned(address: String!): Int!
   coinExchangeRate(pair: ExchangeRatePair!): CoinExchangeRate
-  tokenExchangeRates(filter: TokenExchangeRateFilter!, limit: Int, page: Int, symbols: [String]): [TokenExchangeRate]!
+  tokenExchangeRates(filter: TokenExchangeRateFilter, limit: Int, page: Int, symbols: [String]): [TokenExchangeRate]!
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
   tokenExchangeRateByAddress(address: String!): TokenExchangeRate

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -4,11 +4,11 @@ type Query {
   addressAllTokensOwned(address: String!): [Token]!
   addressAmountTokensOwned(address: String!): Int!
   coinExchangeRate(pair: ExchangeRatePair!): CoinExchangeRate
-  tokenExchangeRates(filter: TokenExchangeRateFilter!, limit: Int, page: Int): [TokenExchangeRate]!
+  tokenExchangeRates(filter: TokenExchangeRateFilter!, limit: Int, page: Int, symbols: [String]): [TokenExchangeRate]!
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
   tokenExchangeRateByAddress(address: String!): TokenExchangeRate
-  tokensMetadata(symbols: [String]!): [TokenMetadata]
+  tokensMetadata(symbols: [String]): [TokenMetadata]
 }
 
 type Token {

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -57,7 +57,7 @@ export class TokenResolvers {
     @Args() {symbols}: TokenExchangeRatesArgs,
     @Args('filter') filter: string,
     @Args('limit', ParseLimitPipe) limit?: number,
-    @Args('page', ParsePagePipe) page?: number
+    @Args('page', ParsePagePipe) page?: number,
   ) {
     const entities = await this.tokenService.findTokenExchangeRates(filter, limit, page, symbols)
     return entities.map(e => new TokenExchangeRateDto(e))

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -7,6 +7,7 @@ import {TokenExchangeRateDto} from '@app/graphql/tokens/dto/token-exchange-rate.
 import {TokenMetadataDto} from '@app/graphql/tokens/dto/token-metadata.dto'
 import {ParseLimitPipe} from '@app/shared/validation/parse-limit.pipe.1'
 import {TokenHoldersPageDto} from '@app/graphql/tokens/dto/token-holders-page.dto'
+import {TokenExchangeRatesArgs} from '@app/graphql/tokens/args/token-exchange-rates.args'
 import {TokensMetadataArgs} from '@app/graphql/tokens/args/tokens-metadata.args'
 
 @Resolver('Token')
@@ -52,8 +53,13 @@ export class TokenResolvers {
   }
 
   @Query()
-  async tokenExchangeRates(@Args('filter') filter: string, @Args('limit', ParseLimitPipe) limit?: number, @Args('page', ParsePagePipe) page?: number) {
-    const entities = await this.tokenService.findTokenExchangeRates(filter, limit, page)
+  async tokenExchangeRates(
+    @Args('filter') filter: string,
+    @Args() {symbols}: TokenExchangeRatesArgs,
+    @Args('limit', ParseLimitPipe) limit?: number,
+    @Args('page', ParsePagePipe) page?: number
+  ) {
+    const entities = await this.tokenService.findTokenExchangeRates(filter, limit, page, symbols)
     return entities.map(e => new TokenExchangeRateDto(e))
   }
 

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -54,8 +54,8 @@ export class TokenResolvers {
 
   @Query()
   async tokenExchangeRates(
-    @Args('filter') filter: string,
     @Args() {symbols}: TokenExchangeRatesArgs,
+    @Args('filter') filter: string,
     @Args('limit', ParseLimitPipe) limit?: number,
     @Args('page', ParsePagePipe) page?: number
   ) {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,10 +28,10 @@ volumes:
     #
     # If you're on Mac, make sure you comment the following lines
     # and leave it as a regular docker volume
-    # driver: local-persist
-    # driver_opts:
-    #   name: "paritydb"
-    #   mountpoint: "/var/lib/parity"
+     driver: local-persist
+     driver_opts:
+       name: "paritydb"
+       mountpoint: "/var/lib/parity"
 
 
 services:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,10 +28,10 @@ volumes:
     #
     # If you're on Mac, make sure you comment the following lines
     # and leave it as a regular docker volume
-    driver: local-persist
-    driver_opts:
-      name: "paritydb"
-      mountpoint: "/var/lib/parity"
+    # driver: local-persist
+    # driver_opts:
+    #   name: "paritydb"
+    #   mountpoint: "/var/lib/parity"
 
 
 services:


### PR DESCRIPTION
This PR is for #461 

The tokenExchangeRates query can now search by an array of @symbols. @symbols is not required, so if it is not given, it will default to the previous functionality of returning all exchange rates, and not just those defined in the @symbols param. Additionally, I made the TokenExchangeRateFilter optional, so it will default to marketcap if no filter is given.

tokensMetadata was also edited to make @symbols an optional parameter. If no symbols are given, all results will be returned, rather than just those defined in the @symbols param.