### PR TITLE
fix(migrator): incorrect env variable in flyway conf

### DIFF
--- a/apps/migrator/flyway/flyway.tmpl.conf
+++ b/apps/migrator/flyway/flyway.tmpl.conf
@@ -4,7 +4,7 @@
 # Most drivers are included out of the box.
 # * = JDBC driver must be downloaded and installed in /drivers manually
 # PostgreSQL        : jdbc:postgresql://<host>:<port>/<database>
-flyway.url={{ .Env.FLYWAY_JDBC_URL }}
+flyway.url={{ .Env.POSTGRES_JDBC_URL }}
 
 # The maximum number of retries when attempting to connect to the database. After each failed attempt,
 # Flyway will wait 1 second before attempting to connect again, up to the maximum number of times specified


### PR DESCRIPTION
@aldoborrero it appears during some of your refactor the naming convention for the jdbc url got mixed up. This fixes it. I'm not sure if you want to change the `.env` variable to be `FLYWAY_JDBC_URL` instead.