### PR TITLE
Fix/home page charts error handling

### DIFF
--- a/apps/explorer/src/modules/charts/components/live/ChartLiveTxFees.vue
+++ b/apps/explorer/src/modules/charts/components/live/ChartLiveTxFees.vue
@@ -9,6 +9,8 @@
     unfilled="true"
     :footnotes="footnote"
     :live-chart="true"
+    :data-loading="loading"
+    :error="error"
   />
 </template>
 
@@ -47,8 +49,21 @@ class ChartData {
         limit: MAX_ITEMS
       },
 
+      watchLoading(isLoading) {
+        if (isLoading) {
+          this.error = ''
+        } // clear the error on load
+      },
+
       update({ blockMetrics }) {
         return new BlockMetricPageExt(blockMetrics)
+      },
+
+      error({ graphQLErrors, networkError }) {
+        // TODO refine
+        if (networkError) {
+          this.error = this.$i18n.t('message.no-data')
+        }
       },
 
       subscribeToMore: {
@@ -95,6 +110,8 @@ export default class ChartLiveTxFees extends Vue {
 
   redraw = true
   metricsPage?: BlockMetricPageExt
+
+  error = ''
 
   /*
   ===================================================================================
@@ -250,6 +267,10 @@ export default class ChartLiveTxFees extends Vue {
         icon: 'fa fa-circle'
       }
     ]
+  }
+
+  get loading(): boolean {
+    return this.$apollo.queries.metricsPage.loading
   }
 }
 </script>

--- a/apps/explorer/src/modules/charts/components/live/ChartLiveTxs.vue
+++ b/apps/explorer/src/modules/charts/components/live/ChartLiveTxs.vue
@@ -8,6 +8,8 @@
     :redraw="true"
     :footnotes="footnote"
     :live-chart="true"
+    :data-loading="loading"
+    :error="error"
   />
 </template>
 
@@ -49,8 +51,21 @@ class ChartData {
         limit: MAX_ITEMS
       },
 
+      watchLoading(isLoading) {
+        if (isLoading) {
+          this.error = ''
+        } // clear the error on load
+      },
+
       update({ blockSummaries }) {
         return new BlockSummaryPageExt(blockSummaries)
+      },
+
+      error({ graphQLErrors, networkError }) {
+        // TODO refine
+        if (networkError) {
+          this.error = this.$i18n.t('message.no-data')
+        }
       },
 
       subscribeToMore: {
@@ -96,6 +111,7 @@ export default class ChartLiveTxs extends Vue {
     */
 
   blockPage?: BlockSummaryPageExt
+  error = ''
 
   /*
     ===================================================================================
@@ -192,6 +208,10 @@ export default class ChartLiveTxs extends Vue {
 
   get newDescription() {
     return this.$i18n.t('charts.tx-summary.description')
+  }
+
+  get loading(): boolean {
+    return this.$apollo.queries.blockPage.loading
   }
 
   get chartOptions() {


### PR DESCRIPTION
I accidentally broke these while integrating charts with apollo error handling. They are now fixed.