### PR TITLE
#489 - Feature findTokenTransfersByContractAddressesForHolder

### DIFF
--- a/apps/api/src/dao/transfer.service.ts
+++ b/apps/api/src/dao/transfer.service.ts
@@ -62,6 +62,58 @@ export class TransferService {
 
   }
 
+  async findTokenTransfersByContractAddressesForHolder(
+    addresses: string[],
+    holder: string,
+    filter: string = 'all',
+    take: number = 10,
+    page: number = 0,
+    timestampFrom: number = 0,
+    timestampTo: number = 0
+  ): Promise<[FungibleBalanceTransferEntity[], number]> {
+    const skip = take * page
+
+    const builder = this.transferRepository.createQueryBuilder('t')
+      .where('t.contract_address = ANY(:addresses)')
+      .andWhere('t.delta_type = :deltaType')
+
+    switch (filter) {
+      case 'in':
+        builder.andWhere('t.from = :holder')
+        break
+      case 'out':
+        builder.andWhere('t.to = :holder')
+        break
+      default:
+        builder.andWhere(new Brackets(sqb => {
+          sqb.where('t.from = :holder')
+          sqb.orWhere('t.to = :holder')
+        }))
+        break
+    }
+
+    if (timestampFrom > 0) {
+      builder.andWhere(new Brackets(sqb => {
+        sqb.where('t.timestamp > :timestampFrom')
+      }))
+    }
+
+    if (timestampTo > 0) {
+      builder.andWhere(new Brackets(sqb => {
+        sqb.where('t.timestamp < :timestampTo')
+      }))
+    }
+
+    return builder
+      .setParameters({ addresses, deltaType: 'TOKEN_TRANSFER', holder, timestampFrom, timestampTo })
+      .orderBy('t.traceLocationBlockNumber', 'DESC')
+      .addOrderBy('t.traceLocationTransactionIndex', 'DESC')
+      .offset(skip)
+      .take(take)
+      .getManyAndCount()
+
+  }
+
   async findInternalTransactionsByAddress(address: string, take: number = 10, page: number = 0): Promise<[FungibleBalanceTransferEntity[], number]> {
     const skip = take * page
     const deltaTypes = ['INTERNAL_TX', 'CONTRACT_CREATION', 'CONTRACT_DESTRUCTION']

--- a/apps/api/src/dao/transfer.service.ts
+++ b/apps/api/src/dao/transfer.service.ts
@@ -76,7 +76,7 @@ export class TransferService {
     take: number = 10,
     page: number = 0,
     timestampFrom: number = 0,
-    timestampTo: number = 0
+    timestampTo: number = 0,
   ): Promise<[FungibleBalanceTransferEntity[], number]> {
     const skip = take * page
 

--- a/apps/api/src/dao/transfer.service.ts
+++ b/apps/api/src/dao/transfer.service.ts
@@ -62,6 +62,13 @@ export class TransferService {
 
   }
 
+  /**
+   * The difference between this query and findTokenTransfersByContractAddressForHolder
+   * is that this query:
+   *
+   * 1) Accepts an array of possible token contractAddresses
+   * 2) Accepts timestampTo/timestampFrom
+   */
   async findTokenTransfersByContractAddressesForHolder(
     addresses: string[],
     holder: string,
@@ -106,8 +113,8 @@ export class TransferService {
 
     return builder
       .setParameters({ addresses, deltaType: 'TOKEN_TRANSFER', holder, timestampFrom, timestampTo })
-      .orderBy('t.traceLocationBlockNumber', 'DESC')
-      .addOrderBy('t.traceLocationTransactionIndex', 'DESC')
+      .orderBy('t.timestamp', 'DESC')
+      // .addOrderBy('t.traceLocationTransactionIndex', 'DESC')
       .offset(skip)
       .take(take)
       .getManyAndCount()

--- a/apps/api/src/dao/transfer.service.ts
+++ b/apps/api/src/dao/transfer.service.ts
@@ -67,7 +67,7 @@ export class TransferService {
    * is that this query:
    *
    * 1) Accepts an array of possible token contractAddresses
-   * 2) Accepts timestampTo/timestampFrom
+   * 2) Accepts timestampTo/timestampFrom and sorts accordingly
    */
   async findTokenTransfersByContractAddressesForHolder(
     addresses: string[],
@@ -114,7 +114,6 @@ export class TransferService {
     return builder
       .setParameters({ addresses, deltaType: 'TOKEN_TRANSFER', holder, timestampFrom, timestampTo })
       .orderBy('t.timestamp', 'DESC')
-      // .addOrderBy('t.traceLocationTransactionIndex', 'DESC')
       .offset(skip)
       .take(take)
       .getManyAndCount()

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -289,9 +289,10 @@ export interface IQuery {
     totalNumTokenExchangeRates(): number | Promise<number>;
     tokenExchangeRateBySymbol(symbol: string): TokenExchangeRate | Promise<TokenExchangeRate>;
     tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
-    tokensMetadata(symbols: string[]): TokenMetadata[] | Promise<TokenMetadata[]>;
+    tokensMetadata(symbols?: string[]): TokenMetadata[] | Promise<TokenMetadata[]>;
     tokenTransfersByContractAddress(contractAddress: string, limit?: number, page?: number): TransfersPage | Promise<TransfersPage>;
     tokenTransfersByContractAddressForHolder(contractAddress: string, holderAddress: string, filter?: FilterEnum, limit?: number, page?: number): TransfersPage | Promise<TransfersPage>;
+    tokenTransfersByContractAddressesForHolder(contractAddresses: string[], holderAddress: string, filter?: FilterEnum, limit?: number, page?: number, timestampFrom?: number, timestampTo?: number): TransfersPage | Promise<TransfersPage>;
     internalTransactionsByAddress(address: string, limit?: number, page?: number): TransfersPage | Promise<TransfersPage>;
     transactionSummaries(fromBlock?: BigNumber, offset?: number, limit?: number): TransactionSummaryPage | Promise<TransactionSummaryPage>;
     transactionSummariesForBlockNumber(number: BigNumber, offset?: number, limit?: number): TransactionSummaryPage | Promise<TransactionSummaryPage>;

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -8,7 +8,7 @@ type Query {
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
   tokenExchangeRateByAddress(address: String!): TokenExchangeRate
-  tokensMetadata(symbols: [String!]!): [TokenMetadata!]!
+  tokensMetadata(symbols: [String]): [TokenMetadata!]!
 }
 
 type Token {

--- a/apps/api/src/graphql/transfers/transfer.graphql
+++ b/apps/api/src/graphql/transfers/transfer.graphql
@@ -1,6 +1,7 @@
 type Query {
   tokenTransfersByContractAddress(contractAddress: String!, limit: Int = 20, page: Int = 0): TransfersPage!
   tokenTransfersByContractAddressForHolder(contractAddress: String!, holderAddress: String!, filter: FilterEnum = all, limit: Int = 20, page: Int = 0): TransfersPage!
+  tokenTransfersByContractAddressesForHolder(contractAddresses: [String!], holderAddress: String!, filter: FilterEnum = all, limit: Int = 20, page: Int = 0, timestampFrom: Int = 0, timestampTo: Int = 0): TransfersPage
   internalTransactionsByAddress(address: String!, limit: Int = 20, page: Int = 0): TransfersPage!
 }
 

--- a/apps/api/src/graphql/transfers/transfer.resolvers.ts
+++ b/apps/api/src/graphql/transfers/transfer.resolvers.ts
@@ -1,10 +1,8 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { TransferService } from '@app/dao/transfer.service'
-import {ParseAddressPipe} from '@app/shared/validation/parse-address.pipe'
-import {ParseAddressesPipe} from '@app/shared/validation/parse-addresses.pipe'
-import {ParseLimitPipe} from '@app/shared/validation/parse-limit.pipe.1'
-import {ParsePagePipe} from '@app/shared/validation/parse-page.pipe'
-import {TransfersPageDto} from '@app/graphql/transfers/dto/transfers-page.dto'
+import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
+import { ParseAddressesPipe } from '@app/shared/validation/parse-addresses.pipe'
+import { TransfersPageDto } from '@app/graphql/transfers/dto/transfers-page.dto'
 
 @Resolver('Transfer')
 export class TransferResolvers {
@@ -49,7 +47,8 @@ export class TransferResolvers {
     @Args('timestampFrom') timestampFrom: number,
     @Args('timestampTo') timestampTo: number,
   ): Promise<TransfersPageDto> {
-    const result = await this.transferService.findTokenTransfersByContractAddressesForHolder(contractAddresses, holderAddress, filter, limit, page, timestampFrom, timestampTo)
+    const result = await this.transferService
+      .findTokenTransfersByContractAddressesForHolder(contractAddresses, holderAddress, filter, limit, page, timestampFrom, timestampTo)
     return new TransfersPageDto({
       items: result[0],
       totalCount: result[1],

--- a/apps/api/src/graphql/transfers/transfer.resolvers.ts
+++ b/apps/api/src/graphql/transfers/transfer.resolvers.ts
@@ -1,6 +1,7 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { TransferService } from '@app/dao/transfer.service'
 import {ParseAddressPipe} from '@app/shared/validation/parse-address.pipe'
+import {ParseAddressesPipe} from '@app/shared/validation/parse-addresses.pipe'
 import {ParseLimitPipe} from '@app/shared/validation/parse-limit.pipe.1'
 import {ParsePagePipe} from '@app/shared/validation/parse-page.pipe'
 import {TransfersPageDto} from '@app/graphql/transfers/dto/transfers-page.dto'
@@ -40,7 +41,7 @@ export class TransferResolvers {
 
   @Query()
   async tokenTransfersByContractAddressesForHolder(
-    @Args({name: 'contractAddresses', type: () => [String]}) contractAddresses: string[],
+    @Args({name: 'contractAddresses', type: () => [String]}, ParseAddressesPipe) contractAddresses: string[],
     @Args('holderAddress', ParseAddressPipe) holderAddress: string,
     @Args('filter') filter: string,
     @Args('limit') limit: number,

--- a/apps/api/src/graphql/transfers/transfer.resolvers.ts
+++ b/apps/api/src/graphql/transfers/transfer.resolvers.ts
@@ -39,6 +39,23 @@ export class TransferResolvers {
   }
 
   @Query()
+  async tokenTransfersByContractAddressesForHolder(
+    @Args({name: 'contractAddresses', type: () => [String]}) contractAddresses: string[],
+    @Args('holderAddress', ParseAddressPipe) holderAddress: string,
+    @Args('filter') filter: string,
+    @Args('limit') limit: number,
+    @Args('page') page: number,
+    @Args('timestampFrom') timestampFrom: number,
+    @Args('timestampTo') timestampTo: number,
+  ): Promise<TransfersPageDto> {
+    const result = await this.transferService.findTokenTransfersByContractAddressesForHolder(contractAddresses, holderAddress, filter, limit, page, timestampFrom, timestampTo)
+    return new TransfersPageDto({
+      items: result[0],
+      totalCount: result[1],
+    })
+  }
+
+  @Query()
   async internalTransactionsByAddress(
     @Args('address', ParseAddressPipe) address: string,
     @Args('limit') limit: number,

--- a/apps/api/src/shared/validation/parse-addresses.pipe.ts
+++ b/apps/api/src/shared/validation/parse-addresses.pipe.ts
@@ -12,7 +12,7 @@ export class ParseAddressesPipe implements PipeTransform<string[], string[]> {
       }
       if (val.substring(0, 2) !== '0x') {
         val = `0x${val}`
-      }      
+      }
     })
     return value
   }

--- a/apps/api/src/shared/validation/parse-addresses.pipe.ts
+++ b/apps/api/src/shared/validation/parse-addresses.pipe.ts
@@ -1,0 +1,19 @@
+import { ArgumentMetadata, BadRequestException, Injectable, PipeTransform } from '@nestjs/common'
+import { EthService } from '@app/shared/eth.service'
+
+@Injectable()
+export class ParseAddressesPipe implements PipeTransform<string[], string[]> {
+  constructor(private readonly ethService: EthService) {}
+
+  transform(value: string[], metadata: ArgumentMetadata): string[] {
+    value.forEach(val => {
+      if (!this.ethService.isValidAddress(val)) {
+        throw new BadRequestException('Invalid address hash')
+      }
+      if (val.substring(0, 2) !== '0x') {
+        val = `0x${val}`
+      }      
+    })
+    return value
+  }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,10 +28,10 @@ volumes:
     #
     # If you're on Mac, make sure you comment the following lines
     # and leave it as a regular docker volume
-    driver: local-persist
-    driver_opts:
-      name: "paritydb"
-      mountpoint: "${PARITY_VOLUME_MOUNTPOINT}"
+    # driver: local-persist
+    # driver_opts:
+    #   name: "paritydb"
+    #   mountpoint: "${PARITY_VOLUME_MOUNTPOINT}"
 
 services:
 


### PR DESCRIPTION
This completes #489.

Additionally, I changed the tokensMetadata query to have symbols as an optional param, as originally intended.

**Test Query:**

```
tokenTransfersByContractAddressesForHolder(
    contractAddresses: ["0xade20230c260f1fd46cd70174dd58363929fea31", "0x9def739163abbae8c81343619e8415a926ffa5fd"],
    holderAddress: "0x3a357ea16210e1bfe0bc1e1a5d811a13365334c3",
    filter: all,
    timestampFrom: 1479740032,
    timestampTo: 1579740033
  ) {
    items {
      traceLocationTransactionHash
    },
    totalCount
  }
```

**Notes:**

I'm not sure the timestamp querying is done "properly", utilizing timescaleDB.