### PR TITLE
Fix/address detail total txs

### DIFF
--- a/apps/api/src/dao/tx.service.ts
+++ b/apps/api/src/dao/tx.service.ts
@@ -250,7 +250,13 @@ export class TxService {
     return Array.from(txsByHash.values())
   }
 
-  async countTransactions(): Promise<number> {
+  async countTransactions(address?: string): Promise<number> {
+
+    if (address) {
+      return this.transactionRepository.count({ where:  [{ from: address }, { to: address }]  })
+    }
+
     return this.transactionRepository.count()
   }
+
 }

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -300,6 +300,7 @@ export interface IQuery {
     txs(limit?: number, page?: number, fromBlock?: BigNumber): Transaction[] | Promise<Transaction[]>;
     txsForAddress(hash: string, filter?: FilterEnum, limit?: number, page?: number): Transaction[] | Promise<Transaction[]>;
     totalNumberOfTransactions(): BigNumber | Promise<BigNumber>;
+    countTxsForAddress(address: string): BigNumber | Promise<BigNumber>;
     uncleByHash(hash: string): Uncle | Promise<Uncle>;
     uncles(offset?: number, limit?: number, fromUncle?: BigNumber): UnclePage | Promise<UnclePage>;
     totalNumberOfUncles(): BigNumber | Promise<BigNumber>;

--- a/apps/api/src/graphql/txs/tx.graphql
+++ b/apps/api/src/graphql/txs/tx.graphql
@@ -9,6 +9,7 @@ type Query {
   txs(limit: Int = 20, page: Int = 0, fromBlock: BigNumber): [Transaction!]!
   txsForAddress(hash: String!, filter: FilterEnum = all, limit: Int = 20, page: Int = 0): [Transaction!]!
   totalNumberOfTransactions: BigNumber!
+  countTxsForAddress(address: String!): BigNumber!
 }
 
 type Subscription {

--- a/apps/api/src/graphql/txs/tx.resolvers.ts
+++ b/apps/api/src/graphql/txs/tx.resolvers.ts
@@ -81,6 +81,12 @@ export class TxResolvers {
   async totalNumberOfTransactions(): Promise<number> {
     return await this.txService.countTransactions()
   }
+
+  @Query()
+  async countTxsForAddress(@Args('address', ParseAddressPipe) address: string): Promise<number> {
+    return await this.txService.countTransactions(address)
+  }
+
   @Subscription(
     'newTransaction', {
       resolve: (summary: TransactionSummary) => new TransactionSummaryDto(summary),

--- a/apps/explorer/apollo/schemas/api.json
+++ b/apps/explorer/apollo/schemas/api.json
@@ -1395,6 +1395,37 @@
             "deprecationReason": null
           },
           {
+            "name": "countTxsForAddress",
+            "description": null,
+            "args": [
+              {
+                "name": "address",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BigNumber",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "uncleByHash",
             "description": null,
             "args": [

--- a/apps/explorer/src/core/api/apollo/types/UnclePage.ts
+++ b/apps/explorer/src/core/api/apollo/types/UnclePage.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: UnclePage
+// ====================================================
+
+export interface UnclePage_items {
+  __typename: "Uncle";
+  author: string;
+  number: any;
+  hash: string;
+  nephewNumber: any;
+  uncleIndex: number;
+  uncleReward: any;
+}
+
+export interface UnclePage {
+  __typename: "UnclePage";
+  items: UnclePage_items[];
+  totalCount: number;
+}

--- a/apps/explorer/src/core/api/apollo/types/uncleSummaries.ts
+++ b/apps/explorer/src/core/api/apollo/types/uncleSummaries.ts
@@ -1,0 +1,33 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: uncleSummaries
+// ====================================================
+
+export interface uncleSummaries_summaries_items {
+  __typename: "Uncle";
+  author: string;
+  number: any;
+  hash: string;
+  nephewNumber: any;
+  uncleIndex: number;
+  uncleReward: any;
+}
+
+export interface uncleSummaries_summaries {
+  __typename: "UnclePage";
+  items: uncleSummaries_summaries_items[];
+  totalCount: number;
+}
+
+export interface uncleSummaries {
+  summaries: uncleSummaries_summaries;
+}
+
+export interface uncleSummariesVariables {
+  offset?: number | null;
+  limit?: number | null;
+  fromUncle?: any | null;
+}

--- a/apps/explorer/src/modules/addresses/addresses.graphql
+++ b/apps/explorer/src/modules/addresses/addresses.graphql
@@ -1,0 +1,3 @@
+query totalTxsForAddress($address: String!) {
+  totalTxs: countTxsForAddress(address: $address)
+}

--- a/apps/explorer/src/modules/addresses/components/AddressDetail.vue
+++ b/apps/explorer/src/modules/addresses/components/AddressDetail.vue
@@ -76,7 +76,7 @@
           <v-flex xs12 md4>
             <v-card class="warning white--text pl-2" flat>
               <v-card-text class="pb-0">{{ $t('tx.total') }}</v-card-text>
-              <v-card-title class="headline text-truncate">{{ formatStr(account.totalTxs.toString()) }}</v-card-title>
+              <v-card-title class="headline text-truncate">{{ totalTxsString }}</v-card-title>
             </v-card>
           </v-flex>
           <!-- End Number of Tx -->
@@ -107,7 +107,7 @@
 
           <v-card class="warning white--text xs-div" flat>
             <v-card-text class="pb-0">{{ $t('tx.total') }}</v-card-text>
-            <v-card-title class="headline text-truncate">{{ formatStr(account.totalTxs.toString()) }}</v-card-title>
+            <v-card-title class="headline text-truncate">{{ totalTxsString }}</v-card-title>
           </v-card>
 
           <div class="empty-xs"></div>
@@ -123,13 +123,28 @@ import AddressQr from '@app/modules/addresses/components/AddressQr.vue'
 import AppCopyToClip from '@app/core/components/ui/AppCopyToClip.vue'
 import Blockies from '@app/modules/addresses/components/Blockies.vue'
 import { AccountInfo } from '@app/modules/addresses/props'
-import { Vue, Component, Prop, Mixins } from 'vue-property-decorator'
+import { Component, Prop, Mixins } from 'vue-property-decorator'
+import { totalTxsForAddress } from '@app/modules/addresses/addresses.graphql'
+import BigNumber from 'bignumber.js'
 
 @Component({
   components: {
     AddressQr,
     AppCopyToClip,
     Blockies
+  },
+  apollo: {
+    totalTxs: {
+      query: totalTxsForAddress,
+      variables() {
+        return {
+          address: this.address
+        }
+      },
+      update({ totalTxs }) {
+        return new BigNumber(totalTxs || 0)
+      }
+    }
   }
 })
 export default class AddressDetail extends Mixins(StringConcatMixin) {
@@ -140,6 +155,9 @@ export default class AddressDetail extends Mixins(StringConcatMixin) {
   */
 
   @Prop(Object) account!: AccountInfo
+  @Prop(String!) address!: string
+
+  totalTxs?: BigNumber
 
   /*
   ===================================================================================
@@ -168,6 +186,13 @@ export default class AddressDetail extends Mixins(StringConcatMixin) {
       default:
         return 'pa-3'
     }
+  }
+
+  get totalTxsString(): string {
+    if (this.$apollo.loading) {
+      return this.$i18n.t('message.load').toString()
+    }
+    return this.totalTxs ? this.totalTxs.toString() : '0'
   }
 }
 </script>

--- a/apps/explorer/src/modules/addresses/pages/PageDetailsAddress.vue
+++ b/apps/explorer/src/modules/addresses/pages/PageDetailsAddress.vue
@@ -13,7 +13,7 @@
     -->
     <v-layout v-if="!loading && !hasError" row wrap justify-start class="mb-4">
       <v-flex xs12>
-        <address-detail :account="account" :type-addrs="detailsType" />
+        <address-detail :account="account" :type-addrs="detailsType" :address="addressRef" />
       </v-flex>
     </v-layout>
     <!--


### PR DESCRIPTION
AddressDetail total txs card would always show "0" for a contract because totalTxs was based on account.totalTxs which is not set on contracts. I added a query countTxsForAddress and used this in AddressDetail, integrating with vue-apollo, to load totalTxs data directly in component and display when loaded.