### PR TITLE
fix /tx summaries bug when no hashes provided

### DIFF
--- a/apps/api/src/dao/tx.service.ts
+++ b/apps/api/src/dao/tx.service.ts
@@ -202,6 +202,8 @@ export class TxService {
 
   async findSummariesByHash(hashes: string[], entityManager: EntityManager = this.entityManager): Promise<TransactionSummary[]> {
 
+    if (!(hashes && hashes.length)) return []
+
     const manager = entityManager || this.entityManager
 
     const txs = await manager


### PR DESCRIPTION
Ensure an empty array is returned if no hashes are provided to findSummariesByHash()