### PR TITLE
fix: introduce count table to speed up queries

### DIFF
--- a/apps/api/src/dao/block-metrics.service.ts
+++ b/apps/api/src/dao/block-metrics.service.ts
@@ -35,10 +35,10 @@ export class BlockMetricsService {
         const [{ count }] = await txn.find(RowCount, {
           select: ['count'],
           where: {
-            relation: 'canonical_block_header'
-          }
+            relation: 'canonical_block_header',
+          },
         })
-        
+
         // cheaper to look up the block hashes from canonical block header first and use timestamp to filter down
         // the hypertable
         const headers = await txn

--- a/apps/api/src/dao/block-metrics.service.ts
+++ b/apps/api/src/dao/block-metrics.service.ts
@@ -7,6 +7,7 @@ import { unitOfTime } from 'moment'
 import BigNumber from 'bignumber.js'
 import { BlockHeaderEntity } from '@app/orm/entities/block-header.entity'
 import moment = require('moment')
+import { RowCount } from '@app/orm/entities/row-counts.entity'
 
 @Injectable()
 export class BlockMetricsService {
@@ -31,9 +32,13 @@ export class BlockMetricsService {
         // much cheaper to do the count against canonical block header table instead of using the
         // usual count mechanism
 
-        const [{ count }] = await txn
-          .query('select count(number) from canonical_block_header') as [{ count: number }]
-
+        const [{ count }] = await txn.find(RowCount, {
+          select: ['count'],
+          where: {
+            relation: 'canonical_block_header'
+          }
+        })
+        
         // cheaper to look up the block hashes from canonical block header first and use timestamp to filter down
         // the hypertable
         const headers = await txn

--- a/apps/api/src/dao/block.service.ts
+++ b/apps/api/src/dao/block.service.ts
@@ -11,6 +11,7 @@ import { TraceService } from './trace.service'
 import { PartialReadException } from '@app/shared/errors/partial-read-exception'
 import { setEquals } from '@app/shared/utils'
 import { ConfigService } from '@app/shared/config.service'
+import { RowCount } from '@app/orm/entities/row-counts.entity'
 
 @Injectable()
 export class BlockService {
@@ -21,7 +22,7 @@ export class BlockService {
     @InjectRepository(UncleEntity) private readonly uncleRepository: Repository<UncleEntity>,
     @InjectEntityManager() private readonly entityManager: EntityManager,
     private readonly traceService: TraceService,
-    private readonly configService: ConfigService,
+    private readonly configService: ConfigService
   ) {
   }
 
@@ -32,7 +33,7 @@ export class BlockService {
       .find({
         select: ['number', 'difficulty', 'blockTime'],
         order: { number: 'DESC' },
-        take: 20,
+        take: 20
       })
 
     if (blocks.length === 0) return null
@@ -56,8 +57,12 @@ export class BlockService {
 
           const where = fromBlock ? { number: LessThanOrEqual(fromBlock) } : {}
 
-          const [ { count } ] = await txn
-            .query('select count(number) from canonical_block_header') as [{ count: number }]
+          const [{ count }] = await txn.find(RowCount, {
+            select: ['count'],
+            where: {
+              relation: 'canonical_block_header'
+            }
+          })
 
           const headersWithRewards = await txn.find(BlockHeaderEntity, {
             select: ['number', 'hash', 'author', 'transactionHashes', 'uncleHashes', 'difficulty', 'timestamp'],
@@ -65,12 +70,12 @@ export class BlockService {
             relations: ['rewards'],
             order: { number: 'DESC' },
             skip: offset,
-            take: limit,
+            take: limit
           })
 
           return [
             await this.summarise(txn, headersWithRewards),
-            count,
+            count
           ]
 
         })
@@ -86,14 +91,14 @@ export class BlockService {
         relations: ['rewards'],
         order: { number: 'DESC' },
         skip: offset,
-        take: limit,
+        take: limit
       })
 
     if (count === 0) return [[], count]
 
     return [
       await this.summarise(this.entityManager, headersWithRewards),
-      count,
+      count
     ]
 
   }
@@ -104,7 +109,7 @@ export class BlockService {
       select: ['number', 'hash', 'author', 'transactionHashes', 'uncleHashes', 'difficulty', 'timestamp'],
       where: { hash: In(blockHashes) },
       relations: ['rewards'],
-      order: { number: 'DESC' },
+      order: { number: 'DESC' }
     })
 
     return this.summarise(this.entityManager, headersWithRewards)
@@ -176,7 +181,7 @@ export class BlockService {
         numTxs: transactionHashes.length,
         numSuccessfulTxs: successfulCountByBlock.get(hash) || 0,
         numFailedTxs: failedCountByBlock.get(hash) || 0,
-        reward: rewardsByBlock.get(hash) || 0,
+        reward: rewardsByBlock.get(hash) || 0
       } as BlockSummary
 
     })

--- a/apps/api/src/dao/block.service.ts
+++ b/apps/api/src/dao/block.service.ts
@@ -22,7 +22,7 @@ export class BlockService {
     @InjectRepository(UncleEntity) private readonly uncleRepository: Repository<UncleEntity>,
     @InjectEntityManager() private readonly entityManager: EntityManager,
     private readonly traceService: TraceService,
-    private readonly configService: ConfigService
+    private readonly configService: ConfigService,
   ) {
   }
 
@@ -33,7 +33,7 @@ export class BlockService {
       .find({
         select: ['number', 'difficulty', 'blockTime'],
         order: { number: 'DESC' },
-        take: 20
+        take: 20,
       })
 
     if (blocks.length === 0) return null
@@ -60,8 +60,8 @@ export class BlockService {
           const [{ count }] = await txn.find(RowCount, {
             select: ['count'],
             where: {
-              relation: 'canonical_block_header'
-            }
+              relation: 'canonical_block_header',
+            },
           })
 
           const headersWithRewards = await txn.find(BlockHeaderEntity, {
@@ -70,12 +70,12 @@ export class BlockService {
             relations: ['rewards'],
             order: { number: 'DESC' },
             skip: offset,
-            take: limit
+            take: limit,
           })
 
           return [
             await this.summarise(txn, headersWithRewards),
-            count
+            count,
           ]
 
         })
@@ -91,14 +91,14 @@ export class BlockService {
         relations: ['rewards'],
         order: { number: 'DESC' },
         skip: offset,
-        take: limit
+        take: limit,
       })
 
     if (count === 0) return [[], count]
 
     return [
       await this.summarise(this.entityManager, headersWithRewards),
-      count
+      count,
     ]
 
   }
@@ -109,7 +109,7 @@ export class BlockService {
       select: ['number', 'hash', 'author', 'transactionHashes', 'uncleHashes', 'difficulty', 'timestamp'],
       where: { hash: In(blockHashes) },
       relations: ['rewards'],
-      order: { number: 'DESC' }
+      order: { number: 'DESC' },
     })
 
     return this.summarise(this.entityManager, headersWithRewards)
@@ -181,7 +181,7 @@ export class BlockService {
         numTxs: transactionHashes.length,
         numSuccessfulTxs: successfulCountByBlock.get(hash) || 0,
         numFailedTxs: failedCountByBlock.get(hash) || 0,
-        reward: rewardsByBlock.get(hash) || 0
+        reward: rewardsByBlock.get(hash) || 0,
       } as BlockSummary
 
     })

--- a/apps/api/src/dao/contract.service.ts
+++ b/apps/api/src/dao/contract.service.ts
@@ -39,6 +39,7 @@ export class ContractService {
         const where = { creator }
 
         const count = await txn.count(ContractEntity, { where })
+
         const contracts = await txn.find(ContractEntity, {
           select: ['address', 'creator', 'traceCreatedAtBlockNumber', 'traceCreatedAtTransactionHash'],
           where,

--- a/apps/api/src/dao/tx.service.ts
+++ b/apps/api/src/dao/tx.service.ts
@@ -23,7 +23,7 @@ export class TxService {
     @InjectRepository(TransactionEntity)
     private readonly transactionRepository: Repository<TransactionEntity>,
     @InjectEntityManager()
-    private readonly entityManager: EntityManager
+    private readonly entityManager: EntityManager,
   ) {
   }
 
@@ -71,12 +71,12 @@ export class TxService {
           select: ['hash'],
           where,
           skip: offset,
-          take: limit
+          take: limit,
         })
 
         const summaries = await this.findSummariesByHash(txs.map(t => t.hash), txn)
         return [summaries, count]
-      }
+      },
     )
 
   }
@@ -98,12 +98,12 @@ export class TxService {
           select: ['hash'],
           where,
           skip: offset,
-          take: limit
+          take: limit,
         })
 
         const summaries = await this.findSummariesByHash(txs.map(t => t.hash), txn)
         return [summaries, count]
-      }
+      },
     )
 
   }
@@ -145,12 +145,12 @@ export class TxService {
           select: ['hash'],
           where,
           skip: offset,
-          take: limit
+          take: limit,
         })
 
         const summaries = await this.findSummariesByHash(txs.map(t => t.hash), txn)
         return [summaries, count]
-      }
+      },
     )
 
   }
@@ -166,10 +166,9 @@ export class TxService {
         let [{ count: totalCount }] = await entityManager.find(RowCount, {
           select: ['count'],
           where: {
-            relation: 'transaction'
-          }
+            relation: 'transaction',
+          },
         })
-
 
         if (totalCount === 0) return [[], totalCount]
 
@@ -178,8 +177,8 @@ export class TxService {
           // this is much faster way of determining the count
           const filterCount = await entityManager.count(TransactionEntity, {
             where: {
-              blockNumber: MoreThan(fromBlock)
-            }
+              blockNumber: MoreThan(fromBlock),
+            },
           })
 
           totalCount = totalCount - filterCount
@@ -190,10 +189,10 @@ export class TxService {
           where,
           order: {
             blockNumber: 'DESC',
-            transactionIndex: 'DESC'
+            transactionIndex: 'DESC',
           },
           skip: offset,
-          take: limit
+          take: limit,
         })
 
         const receipts = await this.receiptService
@@ -202,7 +201,7 @@ export class TxService {
         const receiptsByTxHash = receipts
           .reduceRight(
             (memo, next) => memo.set(next.transactionHash, next),
-            new Map<string, TransactionReceiptEntity>()
+            new Map<string, TransactionReceiptEntity>(),
           )
 
         const txsWithReceipts = txs.map(tx => {
@@ -210,7 +209,7 @@ export class TxService {
           return new TransactionEntity({ ...tx, receipt })
         })
         return this.summarise(entityManager, txsWithReceipts, totalCount)
-      }
+      },
     )
 
   }
@@ -227,8 +226,8 @@ export class TxService {
         where: { hash: In(hashes) },
         order: {
           blockNumber: 'DESC',
-          transactionIndex: 'DESC'
-        }
+          transactionIndex: 'DESC',
+        },
       })
 
     const receipts = await this.receiptService
@@ -237,7 +236,7 @@ export class TxService {
     const receiptsByTxHash = receipts
       .reduceRight(
         (memo, next) => memo.set(next.transactionHash, next),
-        new Map<string, TransactionReceiptEntity>()
+        new Map<string, TransactionReceiptEntity>(),
       )
 
     const txsWithReceipts = txs.map(tx => {
@@ -319,7 +318,7 @@ export class TxService {
         value: tx.value,
         fee: tx.gasPrice.multipliedBy(receipt.gasUsed),
         successful: txStatus.successful,
-        timestamp: tx.timestamp
+        timestamp: tx.timestamp,
       } as TransactionSummary
     })
 

--- a/apps/api/src/dao/uncle.service.ts
+++ b/apps/api/src/dao/uncle.service.ts
@@ -1,12 +1,18 @@
 import { UncleEntity } from '@app/orm/entities/uncle.entity'
 import { Injectable } from '@nestjs/common'
-import { InjectRepository } from '@nestjs/typeorm'
+import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm'
 import BigNumber from 'bignumber.js'
-import { FindManyOptions, LessThanOrEqual, Repository } from 'typeorm'
+import { EntityManager, FindManyOptions, LessThanOrEqual, MoreThan, Repository } from 'typeorm'
+import { TransactionSummary } from '@app/graphql/schema'
+import { RowCount } from '@app/orm/entities/row-counts.entity'
+import { TransactionEntity } from '@app/orm/entities/transaction.entity'
 
 @Injectable()
 export class UncleService {
-  constructor(@InjectRepository(UncleEntity) private readonly uncleRepository: Repository<UncleEntity>) {
+  constructor(@InjectRepository(UncleEntity)
+              private readonly uncleRepository: Repository<UncleEntity>,
+              @InjectEntityManager()
+              private readonly entityManager: EntityManager) {
   }
 
   async findUncleByHash(hash: string): Promise<UncleEntity | undefined> {
@@ -15,15 +21,44 @@ export class UncleService {
 
   async findUncles(offset: number = 0, limit: number = 20, fromUncle?: BigNumber): Promise<[UncleEntity[], number]> {
 
-    const where = fromUncle ? { number: LessThanOrEqual(fromUncle) } : {}
+    return this.entityManager.transaction(
+      'READ COMMITTED',
+      async (entityManager): Promise<[UncleEntity[], number]> => {
 
-    return this.uncleRepository
-      .findAndCount({
-        where,
-        order: { nephewNumber: 'DESC', number: 'DESC' },
-        skip: offset,
-        take: limit,
+        let [{ count: totalCount }] = await entityManager.find(RowCount, {
+          select: ['count'],
+          where: {
+            relation: 'uncle'
+          }
+        })
+
+        if (totalCount === 0) return [[], totalCount]
+
+        if (fromUncle) {
+          // we count all uncles greater than the from uncle and deduct from total
+          // this is much faster way of determining the count
+          const filterCount = await entityManager.count(UncleEntity, {
+            where: {
+              number: MoreThan(fromUncle)
+            }
+          })
+
+          totalCount = totalCount - filterCount
+        }
+
+        const where = fromUncle ? { number: LessThanOrEqual(fromUncle) } : {}
+
+        const uncles = await entityManager.find(UncleEntity, {
+          where,
+          order: { nephewNumber: 'DESC', number: 'DESC' },
+          skip: offset,
+          take: limit
+        })
+
+        return [uncles, totalCount]
+
       })
+
   }
 
   async findLatestUncleBlockNumber(): Promise<BigNumber> {

--- a/apps/api/src/dao/uncle.service.ts
+++ b/apps/api/src/dao/uncle.service.ts
@@ -28,8 +28,8 @@ export class UncleService {
         let [{ count: totalCount }] = await entityManager.find(RowCount, {
           select: ['count'],
           where: {
-            relation: 'uncle'
-          }
+            relation: 'uncle',
+          },
         })
 
         if (totalCount === 0) return [[], totalCount]
@@ -39,8 +39,8 @@ export class UncleService {
           // this is much faster way of determining the count
           const filterCount = await entityManager.count(UncleEntity, {
             where: {
-              number: MoreThan(fromUncle)
-            }
+              number: MoreThan(fromUncle),
+            },
           })
 
           totalCount = totalCount - filterCount
@@ -52,7 +52,7 @@ export class UncleService {
           where,
           order: { nephewNumber: 'DESC', number: 'DESC' },
           skip: offset,
-          take: limit
+          take: limit,
         })
 
         return [uncles, totalCount]

--- a/apps/api/src/orm/entities/row-counts.entity.ts
+++ b/apps/api/src/orm/entities/row-counts.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm'
+import { assignClean } from '@app/shared/utils'
+
+@Entity('row_count')
+export class RowCount {
+
+  public constructor(data: any) {
+    assignClean(this, data)
+  }
+
+  @PrimaryColumn({ type: 'character varying', length: 128, readonly: true })
+  relation!: string
+
+  @Column({ type: 'bigint', readonly: true })
+  count!: number
+
+}

--- a/apps/migrator/sql/V1__Create_basic_tables.sql
+++ b/apps/migrator/sql/V1__Create_basic_tables.sql
@@ -1,3 +1,34 @@
+/* Count table to speed up count queries */
+
+CREATE TABLE row_count
+(
+  relation VARCHAR(128) PRIMARY KEY,
+  count   BIGINT
+);
+
+INSERT INTO row_count VALUES
+  ('canonical_block_header', 0),
+  ('transaction', 0),
+  ('transaction_trace', 0),
+  ('transaction_receipt', 0),
+  ('uncle', 0);
+
+CREATE OR REPLACE FUNCTION adjust_count()
+  RETURNS TRIGGER AS
+$$
+DECLARE
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    EXECUTE 'UPDATE row_count set count=count +1 where relation = ''' || TG_RELNAME || '''';
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    EXECUTE 'UPDATE row_count set count=count -1 where relation = ''' || TG_RELNAME || '''';
+    RETURN OLD;
+  END IF;
+END;
+$$
+  LANGUAGE 'plpgsql';
+
 /* Canonical blocks table which is updated on fork */
 
 CREATE TABLE canonical_block_header
@@ -30,6 +61,12 @@ CREATE INDEX idx_block_header_number ON canonical_block_header (number DESC);
 CREATE INDEX idx_block_header_hash ON canonical_block_header (hash);
 CREATE INDEX idx_block_header_parent_hash ON canonical_block_header (parent_hash);
 CREATE INDEX idx_block_header_author ON canonical_block_header (author);
+
+CREATE TRIGGER canonical_block_header_count
+  BEFORE INSERT OR DELETE
+  ON canonical_block_header
+  FOR EACH ROW
+EXECUTE PROCEDURE adjust_count();
 
 /* A view to help with address metadata */
 
@@ -105,6 +142,13 @@ CREATE INDEX idx_uncle_nephew_hash ON uncle (nephew_hash);
 CREATE INDEX idx_uncle_number ON uncle (number);
 CREATE INDEX idx_uncle_height ON uncle (height);
 
+CREATE TRIGGER uncle_count
+  BEFORE INSERT OR DELETE
+  ON uncle
+  FOR EACH ROW
+EXECUTE PROCEDURE adjust_count();
+
+
 /* All transactions including possible transactions from old forks */
 CREATE TABLE "transaction"
 (
@@ -134,6 +178,13 @@ CREATE INDEX idx_transaction_to ON TRANSACTION ("to");
 
 CREATE INDEX idx_transaction_transaction_index ON transaction (transaction_index DESC);
 CREATE INDEX idx_transaction_block_number__transaction_index ON transaction (block_number DESC, transaction_index DESC);
+
+CREATE TRIGGER transaction_count
+  BEFORE INSERT OR DELETE
+  ON transaction
+  FOR EACH ROW
+EXECUTE PROCEDURE adjust_count();
+
 
 CREATE FUNCTION notify_transaction() RETURNS TRIGGER AS
 $body$
@@ -198,6 +249,13 @@ CREATE INDEX idx_transaction_receipt_to ON transaction_receipt ("to");
 CREATE INDEX idx_transaction_receipt_from_to ON transaction_receipt ("from", "to");
 CREATE INDEX idx_transaction_receipt_contract_address ON transaction_receipt ("contract_address");
 
+CREATE TRIGGER transaction_receipt_count
+  BEFORE INSERT OR DELETE
+  ON transaction_receipt
+  FOR EACH ROW
+EXECUTE PROCEDURE adjust_count();
+
+
 CREATE FUNCTION notify_transaction_receipt() RETURNS TRIGGER AS
 $body$
 DECLARE
@@ -250,7 +308,14 @@ CREATE TABLE transaction_trace
 CREATE INDEX idx_transaction_trace_block_hash ON transaction_trace (block_hash);
 CREATE INDEX idx_transaction_trace_transaction_hash ON transaction_trace (transaction_hash);
 
-CREATE OR REPLACE FUNCTION notify_transaction_trace() RETURNS TRIGGER AS
+CREATE TRIGGER transaction_trace_count
+  BEFORE INSERT OR DELETE
+  ON transaction_trace
+  FOR EACH ROW
+EXECUTE PROCEDURE adjust_count();
+
+
+CREATE FUNCTION notify_transaction_trace() RETURNS TRIGGER AS
 $body$
 DECLARE
   record  RECORD;
@@ -341,6 +406,13 @@ CREATE TABLE contract
 CREATE INDEX idx_contract_creator ON contract (creator);
 CREATE INDEX idx_contract_contract_type ON contract (contract_type);
 CREATE INDEX idx_contract_trace_created_at_block_hash ON contract (trace_created_at_block_hash);
+
+CREATE TRIGGER contract_count
+  BEFORE INSERT OR DELETE
+  ON contract
+  FOR EACH ROW
+EXECUTE PROCEDURE adjust_count();
+
 
 CREATE VIEW canonical_contract AS
 SELECT c.*

--- a/apps/processing/kafka-streams/src/main/kotlin/com/ethvm/kafka/streams/processors/ContractMetadataProcessor.kt
+++ b/apps/processing/kafka-streams/src/main/kotlin/com/ethvm/kafka/streams/processors/ContractMetadataProcessor.kt
@@ -109,7 +109,6 @@ class ContractMetadataProcessor : AbstractKafkaProcessor() {
 
         // Some values can have non-four-byte-UTF-8 characters
         result?.replace(nonUtf8Regex, "")
-
       }.handle { result, ex ->
         when (ex) {
           null -> result


### PR DESCRIPTION
By introducing a `row_count` relation and attaching a trigger to the main entity relations for updating count on insert/delete we have improved the performance of the count queries which were the main culprit. 

@aldoborrero we can manually patch the staging database to avoid a resync.

Closes #532 