### PR TITLE
fix: #534 live chart loading states

### DIFF
--- a/apps/explorer/src/modules/charts/components/live/ChartLiveTxFees.vue
+++ b/apps/explorer/src/modules/charts/components/live/ChartLiveTxFees.vue
@@ -10,6 +10,7 @@
     :footnotes="footnote"
     :live-chart="true"
     :error="error"
+    :data-loading="loading"
   />
 </template>
 
@@ -162,6 +163,10 @@ export default class ChartLiveTxFees extends Vue {
       Computed Values
     ===================================================================================
     */
+
+  get loading(): boolean {
+    return this.$apollo.queries.metricsPage.loading
+  }
 
   get chartData() {
     const items = this.metricsPage ? this.metricsPage.items || [] : []

--- a/apps/explorer/src/modules/charts/components/live/ChartLiveTxs.vue
+++ b/apps/explorer/src/modules/charts/components/live/ChartLiveTxs.vue
@@ -9,6 +9,7 @@
     :footnotes="footnote"
     :live-chart="true"
     :error="error"
+    :data-loading="loading"
   />
 </template>
 
@@ -165,6 +166,10 @@ export default class ChartLiveTxs extends Vue {
         Computed Values
       ===================================================================================
       */
+
+  get loading(): boolean {
+    return this.$apollo.queries.blockPage.loading
+  }
 
   get chartData() {
     const items = this.blockPage ? this.blockPage.items : []


### PR DESCRIPTION
Pass loading prop correctly to Chart.vue in live chart components. Fixes issue #534 