### PR TITLE
fix/ remove style tags from explorer

### DIFF
--- a/apps/explorer/src/core/components/ui/AppDetailsList.vue
+++ b/apps/explorer/src/core/components/ui/AppDetailsList.vue
@@ -189,10 +189,10 @@ export default class AppDetailsList extends Vue {
 }
 </script>
 <style scoped lang="css">
-  .details-list-title-loading {
-    width: 300px;
-    height: 20px;
-    background: #e6e6e6;
-    border-radius: 2px;
-  }
+.details-list-title-loading {
+  width: 300px;
+  height: 20px;
+  background: #e6e6e6;
+  border-radius: 2px;
+}
 </style>

--- a/apps/explorer/src/core/components/ui/AppDetailsList.vue
+++ b/apps/explorer/src/core/components/ui/AppDetailsList.vue
@@ -13,7 +13,7 @@
     -->
     <div v-if="isLoading && !hasError">
       <v-card-title class="title font-weight-bold pl-4">
-        <div style="width: 300px; height: 20px; background: #e6e6e6; border-radius: 2px;"></div>
+        <div class="details-list-title-loading"></div>
       </v-card-title>
       <v-divider class="lineGrey mt-1 mb-1" />
     </div>
@@ -188,3 +188,11 @@ export default class AppDetailsList extends Vue {
   }
 }
 </script>
+<style scoped lang="css">
+  .details-list-title-loading {
+    width: 300px;
+    height: 20px;
+    background: #e6e6e6;
+    border-radius: 2px;
+  }
+</style>

--- a/apps/explorer/src/core/components/ui/AppDetailsListRow.vue
+++ b/apps/explorer/src/core/components/ui/AppDetailsListRow.vue
@@ -16,7 +16,7 @@
       -->
       <v-flex xs7 sm8 md9 pr-0 v-if="!detail.txInput">
         <div v-if="isLoading">
-          <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+          <v-flex xs12 class="table-row-loading"></v-flex>
         </div>
         <div v-else>
           <div v-if="!isMono">

--- a/apps/explorer/src/core/components/ui/AppInfoCard.vue
+++ b/apps/explorer/src/core/components/ui/AppInfoCard.vue
@@ -15,71 +15,71 @@
 </template>
 
 <script lang="ts">
-  import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Vue, Component, Prop } from 'vue-property-decorator'
 
-  @Component
-  export default class AppInfoCard extends Vue {
-    /*
+@Component
+export default class AppInfoCard extends Vue {
+  /*
     ===================================================================================
       Props
     ===================================================================================
     */
 
-    @Prop(String) value!: string
-    @Prop(String) title!: string
-    @Prop(String) colorType!: string
-    @Prop(String) metrics!: string
-    @Prop(String) backType!: string
+  @Prop(String) value!: string
+  @Prop(String) title!: string
+  @Prop(String) colorType!: string
+  @Prop(String) metrics!: string
+  @Prop(String) backType!: string
 
-    /*
+  /*
     ===================================================================================
       Computed
     ===================================================================================
     */
 
-    get getColor(): string {
-      return this.colorType
-    }
-
-    get getBackground(): string {
-      return this.backType
-    }
+  get getColor(): string {
+    return this.colorType
   }
+
+  get getBackground(): string {
+    return this.backType
+  }
+}
 </script>
 
 <style scoped lang="css">
-  .info-card {
-    padding-top: 42px;
-    padding-left: 24px;
-  }
+.info-card {
+  padding-top: 42px;
+  padding-left: 24px;
+}
 
-  .last-block {
-    background-position: right -10px bottom -17px;
-    background-image: url('~@/assets/smallblocks/cubes-in-stack-with-shadow.svg');
-  }
+.last-block {
+  background-position: right -10px bottom -17px;
+  background-image: url('~@/assets/smallblocks/cubes-in-stack-with-shadow.svg');
+}
 
-  .time-since {
-    background-position: right -10px bottom -17px;
-    background-image: url('~@/assets/smallblocks/hourglass.svg');
-  }
+.time-since {
+  background-position: right -10px bottom -17px;
+  background-image: url('~@/assets/smallblocks/hourglass.svg');
+}
 
-  .hash-rate {
-    background-position: right -10px bottom -17px;
-    background-image: url('~@/assets/smallblocks/hash.svg');
-  }
+.hash-rate {
+  background-position: right -10px bottom -17px;
+  background-image: url('~@/assets/smallblocks/hash.svg');
+}
 
-  .difficulty {
-    background-position: right -10px bottom -17px;
-    background-image: url('~@/assets/smallblocks/dashboard.svg');
-  }
+.difficulty {
+  background-position: right -10px bottom -17px;
+  background-image: url('~@/assets/smallblocks/dashboard.svg');
+}
 
-  .success-txs {
-    background-position: right -10px bottom -17px;
-    background-image: url('~@/assets/smallblocks/target.svg');
-  }
+.success-txs {
+  background-position: right -10px bottom -17px;
+  background-image: url('~@/assets/smallblocks/target.svg');
+}
 
-  .failed-txs {
-    background-position: right -10px bottom -17px;
-    background-image: url('~@/assets/smallblocks/danger-sing.svg');
-  }
+.failed-txs {
+  background-position: right -10px bottom -17px;
+  background-image: url('~@/assets/smallblocks/danger-sing.svg');
+}
 </style>

--- a/apps/explorer/src/core/components/ui/AppInfoCard.vue
+++ b/apps/explorer/src/core/components/ui/AppInfoCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card :color="getColor" :class="getBackground" flat class="mt-1 pr-1 white--text" height="150px" style="padding-top: 42px; padding-left: 24px;">
+  <v-card :color="getColor" :class="getBackground" flat class="mt-1 pr-1 white--text info-card" height="150px">
     <v-layout wrap fill-height>
       <v-flex xs12>
         <v-layout align-end row pr-2>
@@ -15,64 +15,71 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator'
+  import { Vue, Component, Prop } from 'vue-property-decorator'
 
-@Component
-export default class AppInfoCard extends Vue {
-  /*
-  ===================================================================================
-    Props
-  ===================================================================================
-  */
+  @Component
+  export default class AppInfoCard extends Vue {
+    /*
+    ===================================================================================
+      Props
+    ===================================================================================
+    */
 
-  @Prop(String) value!: string
-  @Prop(String) title!: string
-  @Prop(String) colorType!: string
-  @Prop(String) metrics!: string
-  @Prop(String) backType!: string
+    @Prop(String) value!: string
+    @Prop(String) title!: string
+    @Prop(String) colorType!: string
+    @Prop(String) metrics!: string
+    @Prop(String) backType!: string
 
-  /*
-  ===================================================================================
-    Computed
-  ===================================================================================
-  */
+    /*
+    ===================================================================================
+      Computed
+    ===================================================================================
+    */
 
-  get getColor(): string {
-    return this.colorType
+    get getColor(): string {
+      return this.colorType
+    }
+
+    get getBackground(): string {
+      return this.backType
+    }
   }
-
-  get getBackground(): string {
-    return this.backType
-  }
-}
 </script>
 
 <style scoped lang="css">
-.last-block {
-  background-position: right -10px bottom -17px;
-  background-image: url('~@/assets/smallblocks/cubes-in-stack-with-shadow.svg');
-}
+  .info-card {
+    padding-top: 42px;
+    padding-left: 24px;
+  }
 
-.time-since {
-  background-position: right -10px bottom -17px;
-  background-image: url('~@/assets/smallblocks/hourglass.svg');
-}
+  .last-block {
+    background-position: right -10px bottom -17px;
+    background-image: url('~@/assets/smallblocks/cubes-in-stack-with-shadow.svg');
+  }
 
-.hash-rate {
-  background-position: right -10px bottom -17px;
-  background-image: url('~@/assets/smallblocks/hash.svg');
-}
+  .time-since {
+    background-position: right -10px bottom -17px;
+    background-image: url('~@/assets/smallblocks/hourglass.svg');
+  }
 
-.difficulty {
-  background-position: right -10px bottom -17px;
-  background-image: url('~@/assets/smallblocks/dashboard.svg');
-}
-.success-txs {
-  background-position: right -10px bottom -17px;
-  background-image: url('~@/assets/smallblocks/target.svg');
-}
-.failed-txs {
-  background-position: right -10px bottom -17px;
-  background-image: url('~@/assets/smallblocks/danger-sing.svg');
-}
+  .hash-rate {
+    background-position: right -10px bottom -17px;
+    background-image: url('~@/assets/smallblocks/hash.svg');
+  }
+
+  .difficulty {
+    background-position: right -10px bottom -17px;
+    background-image: url('~@/assets/smallblocks/dashboard.svg');
+  }
+
+  .success-txs {
+    background-position: right -10px bottom -17px;
+    background-image: url('~@/assets/smallblocks/target.svg');
+  }
+
+  .failed-txs {
+    background-position: right -10px bottom -17px;
+    background-image: url('~@/assets/smallblocks/danger-sing.svg');
+  }
 </style>

--- a/apps/explorer/src/core/components/ui/AppSearch.vue
+++ b/apps/explorer/src/core/components/ui/AppSearch.vue
@@ -142,11 +142,11 @@ export default class AppSearch extends Vue {
 }
 </script>
 <style scoped lang="css">
-  .search-input-container {
-    height: 48px;
-    border: solid 1px #efefef !important;
-  }
-  .search-button-container {
-    max-width: 115px !important;
-  }
+.search-input-container {
+  height: 48px;
+  border: solid 1px #efefef !important;
+}
+.search-button-container {
+  max-width: 115px !important;
+}
 </style>

--- a/apps/explorer/src/core/components/ui/AppSearch.vue
+++ b/apps/explorer/src/core/components/ui/AppSearch.vue
@@ -1,7 +1,7 @@
 <template>
   <v-layout align-center fill-height justify-end row height="48px" class="pl-1">
     <v-flex xs12 md8>
-      <v-card flat style="height: 48px; border: solid 1px #efefef;">
+      <v-card flat class="search-input-container">
         <v-layout align-center justify-end>
           <v-text-field
             v-model="searchInput"
@@ -35,7 +35,7 @@
         </v-layout>
       </v-card>
     </v-flex>
-    <v-flex hidden-sm-and-down md4 style="max-width: 115px;">
+    <v-flex hidden-sm-and-down md4 class="search-button-container">
       <v-btn v-if="phText === 'default'" @click="onSearch" depressed color="secondary" class="search-button text-capitalize ml-0">{{
         $t('search.name')
       }}</v-btn>
@@ -141,3 +141,12 @@ export default class AppSearch extends Vue {
   }
 }
 </script>
+<style scoped lang="css">
+  .search-input-container {
+    height: 48px;
+    border: solid 1px #efefef !important;
+  }
+  .search-button-container {
+    max-width: 115px !important;
+  }
+</style>

--- a/apps/explorer/src/core/components/ui/AppTabs.vue
+++ b/apps/explorer/src/core/components/ui/AppTabs.vue
@@ -44,11 +44,11 @@
             ripple
             >{{ item.title }}</v-tab
           >
-          <v-tabs-slider color="primary" class="mb-0" style="height: 4px;" />
+          <v-tabs-slider color="primary" class="mb-0 tabs-slider" />
         </v-tabs>
       </v-flex>
     </v-layout>
-    <v-tabs-items v-model="activeTab" style="border-top: 1px solid #efefef">
+    <v-tabs-items v-model="activeTab" class="tabs-items">
       <v-container grid-list-xs :class="tabContainerClass"> <slot name="tabs-item"/></v-container>
     </v-tabs-items>
   </v-card>
@@ -117,4 +117,12 @@ export default class AppTabs extends Vue {
 .v-select__selections{
   color:#6270fc !important;
 }
+
+  .tabs-slider {
+    height: 4px;
+  }
+
+  .tabs-items {
+    border-top: 1px solid #efefef
+  }
 </style>

--- a/apps/explorer/src/css/global.css
+++ b/apps/explorer/src/css/global.css
@@ -77,3 +77,15 @@ p {
     opacity: 0;
     transform: translateY(30px);
 }
+
+/* loading placeholders */
+.table-row-loading {
+  background: #e6e6e6;
+  height: 12px;
+  border-radius: 2px;
+}
+
+/* token images */
+.token-image {
+  width: 25px;
+}

--- a/apps/explorer/src/modules/addresses/components/TableAddressContracts.vue
+++ b/apps/explorer/src/modules/addresses/components/TableAddressContracts.vue
@@ -260,9 +260,4 @@ export default class TableAddressContracts extends Vue {
 .table-row-mobile {
   border: 1px solid #b4bfd2;
 }
-.table-row-loading {
-  background: #e6e6e6;
-  height: 12px;
-  border-radius: 2px;
-}
 </style>

--- a/apps/explorer/src/modules/addresses/components/TableAddressTokens.vue
+++ b/apps/explorer/src/modules/addresses/components/TableAddressTokens.vue
@@ -62,16 +62,16 @@
         <div v-for="i in maxItems" :key="i">
           <v-layout grid-list-xs row wrap align-center justify-start fill-height class="pl-2 pr-2 pt-2">
             <v-flex xs6 sm2>
-              <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+              <v-flex xs12 class="table-row-loading"></v-flex>
             </v-flex>
             <v-flex hidden-xs-only sm4 md3>
-              <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+              <v-flex xs12 class="table-row-loading"></v-flex>
             </v-flex>
             <v-flex xs6 sm3 md4>
-              <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+              <v-flex xs12 class="table-row-loading"></v-flex>
             </v-flex>
             <v-flex idden-xs-only sm3>
-              <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+              <v-flex xs12 class="table-row-loading"></v-flex>
             </v-flex>
           </v-layout>
           <v-divider class="mb-2 mt-2" />

--- a/apps/explorer/src/modules/blocks/components/TableBlocks.vue
+++ b/apps/explorer/src/modules/blocks/components/TableBlocks.vue
@@ -52,7 +52,7 @@
     -->
     <v-layout pl-2 pr-2>
       <v-flex hidden-xs-only sm12>
-        <v-card v-if="!hasError" color="info" flat class="white--text pl-3 pr-1" height="40px" style="margin-right: 1px">
+        <v-card v-if="!hasError" color="info" flat class="white--text pl-3 pr-1 table-blocks-header-card" height="40px">
           <v-layout align-center justify-start row fill-height pr-3>
             <v-flex sm2>
               <h5>{{ $t('block.number') }}</h5>
@@ -85,16 +85,16 @@
           <div v-for="i in maxItems" :key="i">
             <v-layout grid-list-xs row wrap align-center justify-start fill-height class="pl-2 pr-2 pt-2">
               <v-flex xs6 sm2 order-xs1>
-                <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                <v-flex xs12 class="table-row-loading"></v-flex>
               </v-flex>
               <v-flex xs12 sm7 md6>
-                <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                <v-flex xs12 class="table-row-loading"></v-flex>
               </v-flex>
               <v-flex hidden-sm-and-down md2 order-xs4 order-sm3>
-                <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                <v-flex xs12 class="table-row-loading"></v-flex>
               </v-flex>
               <v-flex d-flex xs6 sm3 md2 order-xs2 order-md4>
-                <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                <v-flex xs12 class="table-row-loading"></v-flex>
               </v-flex>
             </v-layout>
             <v-divider class="mb-2 mt-2" />
@@ -353,4 +353,7 @@ export default class TableBlocks extends Vue {
 .title-live {
   min-height: 60px;
 }
+  .table-blocks-header-card {
+    margin-right: 1px
+  }
 </style>

--- a/apps/explorer/src/modules/tokens/components/HolderDetailsList.vue
+++ b/apps/explorer/src/modules/tokens/components/HolderDetailsList.vue
@@ -46,7 +46,7 @@ export default class HolderDetailsList extends Mixins(StringConcatMixin) {
     if (this.isLoading) {
       return ''
     }
-    return `<img src="${this.tokenDetails.image}" class="mr-2" style="width: 25px" />  ${
+    return `<img src="${this.tokenDetails.image}" class="mr-2 token-image" />  ${
       this.tokenDetails.name
     } (${this.tokenDetails.symbol!.toUpperCase()}) - Filtered by Holder`
   }

--- a/apps/explorer/src/modules/tokens/components/TokenDetailsList.vue
+++ b/apps/explorer/src/modules/tokens/components/TokenDetailsList.vue
@@ -44,7 +44,7 @@ export default class TokenDetailsList extends Mixins(StringConcatMixin) {
     if (this.isLoading || this.error !== '') {
       return ''
     }
-    return `<img src="${this.tokenDetails.image}" class="mr-2" style="width: 25px" /> ${this.tokenDetails.name} (${this.tokenDetails.symbol!.toUpperCase()})`
+    return `<img src="${this.tokenDetails.image}" class="mr-2 token-image" /> ${this.tokenDetails.name} (${this.tokenDetails.symbol!.toUpperCase()})`
   }
 
   /**

--- a/apps/explorer/src/modules/tokens/components/TokenTableHolders.vue
+++ b/apps/explorer/src/modules/tokens/components/TokenTableHolders.vue
@@ -254,10 +254,3 @@ export default class TokenTableHolders extends Vue {
   }
 }
 </script>
-<style scoped lang="css">
-.table-row-loading {
-  background: #e6e6e6;
-  height: 12px;
-  border-radius: 2px;
-}
-</style>

--- a/apps/explorer/src/modules/tokens/components/TokenTableRowLoading.vue
+++ b/apps/explorer/src/modules/tokens/components/TokenTableRowLoading.vue
@@ -5,16 +5,16 @@
         <div class="token-mobile">
           <v-layout grid-list-xs row wrap align-center justify-start fill-height>
             <v-flex xs2>
-              <div class="loading"></div>
+              <div class="table-row-loading"></div>
             </v-flex>
             <v-flex xs8>
-              <div class="loading"></div>
-              <div class="loading"></div>
-              <div class="loading"></div>
-              <div class="loading"></div>
+              <div class="table-row-loading"></div>
+              <div class="table-row-loading"></div>
+              <div class="table-row-loading"></div>
+              <div class="table-row-loading"></div>
             </v-flex>
             <v-flex xs2>
-              <div class="loading"></div>
+              <div class="table-row-loading"></div>
             </v-flex>
           </v-layout>
         </div>
@@ -22,22 +22,22 @@
       <v-flex hidden-xs-only sm12>
         <v-layout grid-list-xs row wrap align-center justify-start fill-height class="pl-2 pr-2 pt-2">
           <v-flex xs1>
-            <div class="loading"></div>
+            <div class="table-row-loading"></div>
           </v-flex>
           <v-flex xs2>
-            <div class="loading"></div>
+            <div class="table-row-loading"></div>
           </v-flex>
           <v-flex xs2>
-            <div class="loading"></div>
+            <div class="table-row-loading"></div>
           </v-flex>
           <v-flex xs1>
-            <div class="loading"></div>
+            <div class="table-row-loading"></div>
           </v-flex>
           <v-flex xs3>
-            <div class="loading"></div>
+            <div class="table-row-loading"></div>
           </v-flex>
           <v-flex xs3>
-            <div class="loading"></div>
+            <div class="table-row-loading"></div>
           </v-flex>
         </v-layout>
         <v-divider class="mb-2 mt-2" />
@@ -54,11 +54,8 @@ export default class TokenTableRowLoading extends Vue {}
 </script>
 
 <style scoped lang="css">
-.loading {
-  background: #e6e6e6;
-  height: 12px;
-  border-radius: 2px;
-  margin:1px;
+.table-row-loading {
+  margin: 1px;
 }
 .token-mobile {
   border: 1px solid #b4bfd2;

--- a/apps/explorer/src/modules/transfers/components/TransfersTable.vue
+++ b/apps/explorer/src/modules/transfers/components/TransfersTable.vue
@@ -305,10 +305,3 @@ export default class TransfersTable extends Vue {
   }
 }
 </script>
-<style scoped lang="css">
-.table-row-loading {
-  background: #e6e6e6;
-  height: 12px;
-  border-radius: 2px;
-}
-</style>

--- a/apps/explorer/src/modules/txs/components/TableTxs.vue
+++ b/apps/explorer/src/modules/txs/components/TableTxs.vue
@@ -10,7 +10,7 @@
             <p class="pr-2 ma-0">{{ $t('filter.view') }}:</p>
           </v-flex>
           <v-flex>
-            <v-card flat style="border: solid 1px #efefef; padding-top: 1px;" height="36px" class="pl-2">
+            <v-card flat class="tx-filter-select-container pl-2" height="36px">
               <v-select solo flat hide-details v-model="filter" class="primary body-1" :items="options" item-text="text" item-value="value" height="32px" />
             </v-card>
           </v-flex>
@@ -109,22 +109,22 @@
             <div v-for="i in maxItems" :key="i">
               <v-layout grid-list-xs row wrap align-center justify-start fill-height class="pl-2 pr-2 pt-2">
                 <v-flex xs3 sm3 md1 pl-3>
-                  <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
                 </v-flex>
                 <v-flex xs7 sm6 md6>
-                  <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
                 </v-flex>
                 <v-flex xs2 sm2 md1>
-                  <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
                 </v-flex>
                 <v-flex hidden-sm-and-down md1>
-                  <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
                 </v-flex>
                 <v-flex hidden-sm-and-down md2>
-                  <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
                 </v-flex>
                 <v-flex hidden-xs-only sm1>
-                  <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
                 </v-flex>
               </v-layout>
               <v-divider class="mb-2 mt-2" />
@@ -486,3 +486,9 @@ export default class TableTxs extends TableTxsMixin {
   }
 }
 </script>
+<style scoped lang="css">
+  .tx-filter-select-container {
+    border: solid 1px #efefef;
+    padding-top: 1px;
+  }
+</style>

--- a/apps/explorer/src/modules/txs/components/TableTxs.vue
+++ b/apps/explorer/src/modules/txs/components/TableTxs.vue
@@ -487,8 +487,8 @@ export default class TableTxs extends TableTxsMixin {
 }
 </script>
 <style scoped lang="css">
-  .tx-filter-select-container {
-    border: solid 1px #efefef;
-    padding-top: 1px;
-  }
+.tx-filter-select-container {
+  border: solid 1px #efefef;
+  padding-top: 1px;
+}
 </style>

--- a/apps/explorer/src/modules/uncles/components/TableUncles.vue
+++ b/apps/explorer/src/modules/uncles/components/TableUncles.vue
@@ -69,19 +69,19 @@
         <div v-for="i in maxItems" :key="i">
           <v-layout grid-list-xs row wrap align-center justify-start fill-height pl-3 pr-2 pt-2 pb-1>
             <v-flex xs3 sm2 order-xs1>
-              <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+              <v-flex xs12 class="table-row-loading"></v-flex>
             </v-flex>
             <v-flex xs3 sm2 order-xs1>
-              <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+              <v-flex xs12 class="table-row-loading"></v-flex>
             </v-flex>
             <v-flex xs12 sm5 md5 class="pr-0" order-xs3 order-sm2>
-              <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+              <v-flex xs12 class="table-row-loading"></v-flex>
             </v-flex>
             <v-flex hidden-sm-and-down md1 order-xs4 order-sm3>
-              <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+              <v-flex xs12 class="table-row-loading"></v-flex>
             </v-flex>
             <v-flex d-flex xs6 sm3 md2 order-xs2 order-md4>
-              <v-flex xs12 style="background: #e6e6e6; height: 12px; border-radius: 2px;"></v-flex>
+              <v-flex xs12 class="table-row-loading"></v-flex>
             </v-flex>
           </v-layout>
           <v-divider class="mb-2 mt-2" />


### PR DESCRIPTION
Replace style tags in explorer app with classes. MOve common classes e.g. table-row-loading to global styles to avoid repetition.