### PR TITLE
WIP: Fix/Cors issue when accessing ethvm.lan

### DIFF
--- a/apps/explorer/.env.development
+++ b/apps/explorer/.env.development
@@ -2,3 +2,4 @@ VUE_APP_API_ENDPOINT=http://api.ethvm.lan/graphql
 VUE_APP_API_SUBSCRIPTIONS_ENDPOINT=ws://api.ethvm.lan/graphql
 VUE_APP_SENTRY_SECURITY_TOKEN=''
 VUE_APP_ETH_NETWORK=''
+VUE_APP_PUBLIC_URL='ethvm.lan/'

--- a/apps/explorer/vue.config.js
+++ b/apps/explorer/vue.config.js
@@ -52,8 +52,6 @@ if (publicUrl) {
   devServer.public = publicUrl // Workaround for sockjs-node defaulting to localhost see https://github.com/vuejs/vue-cli/issues/1472
 }
 
-console.log('Dev server config', devServer)
-
 module.exports = {
   chainWebpack: config => {
     config.plugin('html').tap(args => {

--- a/apps/explorer/vue.config.js
+++ b/apps/explorer/vue.config.js
@@ -68,6 +68,6 @@ module.exports = {
   devServer: {
     disableHostCheck: true,
     noInfo: true,
-    public: 'ethvm.lan/'
+    public: 'ethvm.lan/' // Workaround for sockjs-node defaulting to localhost see https://github.com/vuejs/vue-cli/issues/1472
   }
 }

--- a/apps/explorer/vue.config.js
+++ b/apps/explorer/vue.config.js
@@ -41,6 +41,19 @@ const webpackProduction = {
   // }
 }
 
+const publicUrl = process.env.VUE_APP_PUBLIC_URL
+
+const devServer = {
+  disableHostCheck: true,
+  noInfo: true
+}
+
+if (publicUrl) {
+  devServer.public = publicUrl // Workaround for sockjs-node defaulting to localhost see https://github.com/vuejs/vue-cli/issues/1472
+}
+
+console.log('Dev server config', devServer)
+
 module.exports = {
   chainWebpack: config => {
     config.plugin('html').tap(args => {
@@ -65,9 +78,5 @@ module.exports = {
   },
   configureWebpack: process.env.NODE_ENV === 'production' ? merge(webpackCommon, webpackProduction) : webpackCommon,
   productionSourceMap: false,
-  devServer: {
-    disableHostCheck: true,
-    noInfo: true,
-    public: 'ethvm.lan/' // Workaround for sockjs-node defaulting to localhost see https://github.com/vuejs/vue-cli/issues/1472
-  }
+  devServer
 }


### PR DESCRIPTION
 Modify vue config devServer options to override default sockjs-node url to avoid cors error.

┆Progress: QA
