### PR TITLE
Fix: blockByNumber and transactionSummariesForBlockNumber queries

### DIFF
--- a/apps/api/src/dao/tx.service.ts
+++ b/apps/api/src/dao/tx.service.ts
@@ -63,7 +63,7 @@ export class TxService {
         const where = { blockNumber: number }
 
         const [{ count }] = await txn
-          .query('select count(hash) from transaction where block_number = $1', [number]) as [{ count: number }]
+          .query('select count(hash) from transaction where block_number = $1', [number.toNumber()]) as [{ count: number }]
 
         if (count === 0) return [[], count]
 

--- a/apps/explorer/src/modules/blocks/pages/PageDetailsBlock.vue
+++ b/apps/explorer/src/modules/blocks/pages/PageDetailsBlock.vue
@@ -68,7 +68,7 @@ const MAX_TXS = 10
       variables() {
         const { blockNumber, blockHash } = this
         if (blockNumber) {
-          return { blockNumber: blockNumber.toString() }
+          return { blockNumber }
         }
         return { blockHash }
       },
@@ -354,7 +354,7 @@ export default class PageDetailsBlock extends Vue {
     return ''
   }
 
-  get previousBlock(): String {
+  get previousBlock(): string {
     const { blockNumber, blockHash, blockDetail } = this
 
     let number: BigNumber | null = null

--- a/apps/explorer/src/modules/txs/components/TableTxs.vue
+++ b/apps/explorer/src/modules/txs/components/TableTxs.vue
@@ -195,7 +195,7 @@ class TableTxsMixin extends Vue {
         const { blockHash: hash, blockNumber, address, filter } = this
 
         return {
-          number: blockNumber ? blockNumber.toString(10) : undefined,
+          number: blockNumber,
           hash,
           address,
           filter


### PR DESCRIPTION
Fixes #567. New counting method was broken for counting txs by block number, fixed by converting number param from BigNumber to number before passing to postgres.