### PR TITLE
fix: Historical charts BigNumber conversion

### DIFF
--- a/apps/explorer/src/modules/charts/components/history/ChartTimeseries.vue
+++ b/apps/explorer/src/modules/charts/components/history/ChartTimeseries.vue
@@ -158,11 +158,11 @@ export default class ChartTimeseries extends Vue {
       case 'any':
         return value
       case 'bignumber':
-        return new BigNumber(value, 16)
+        return new BigNumber(value)
       case 'eth':
-        return new EthValue(new BigNumber(value, 16)).toEth()
+        return new EthValue(new BigNumber(value)).toEth()
       case 'gwei':
-        return new EthValue(new BigNumber(value, 16)).toGWei()
+        return new EthValue(new BigNumber(value)).toGWei()
       default:
         throw new Error(`Unexpected valueType: ${this.valueType}`)
     }


### PR DESCRIPTION
Fixes #562 and #563. Data points in timeseries charts were being converted to BigNumber with base 16. This is out-dated and is now updated to use default base 10 when creating new BigNumbers.