### PR TITLE
fix: Tx fees format in TableTxsRow

### DIFF
--- a/apps/explorer/src/modules/txs/components/TableTxsRow.vue
+++ b/apps/explorer/src/modules/txs/components/TableTxsRow.vue
@@ -147,7 +147,7 @@
           =====================================================================================
           -->
           <v-flex hidden-sm-and-down md1>
-            <p class="black--text text-truncate mb-0">{{ ethValue(tx.feeBN).toEth() }}</p>
+            <p class="black--text text-truncate mb-0">{{ ethValue(tx.feeBN.toFixed()).toEth() }}</p>
           </v-flex>
           <!--
           =====================================================================================


### PR DESCRIPTION
Convert tx.feeBN toFormat() to avoid exponential notation on very small numbers. Fixes #541.