### PR TITLE
fix: Block metrics resolvers unit tests

### DIFF
--- a/apps/api/src/dao/block-metrics.service.ts
+++ b/apps/api/src/dao/block-metrics.service.ts
@@ -19,8 +19,8 @@ export class BlockMetricsService {
     return this.entityManager
       .find(BlockMetricEntity, {
         where: {
-          blockHash: In(blockHashes)
-        }
+          blockHash: In(blockHashes),
+        },
       })
   }
 
@@ -35,14 +35,14 @@ export class BlockMetricsService {
         const [{ count }] = await txn.find(RowCount, {
           select: ['count'],
           where: {
-            relation: 'canonical_block_header'
-          }
+            relation: 'canonical_block_header',
+          },
         })
 
         const entities = await txn.find(BlockMetricsTransactionEntity, {
           order: { number: 'DESC' },
           skip: offset,
-          take: limit
+          take: limit,
         })
 
         return [entities, count]
@@ -52,7 +52,7 @@ export class BlockMetricsService {
 
   async findBlockMetricsTransactionByBlockHash(blockHash: string): Promise<BlockMetricsTransactionEntity | undefined> {
     return this.entityManager.findOne(BlockMetricsTransactionEntity, {
-      where: { blockHash }
+      where: { blockHash },
     })
   }
 
@@ -67,14 +67,14 @@ export class BlockMetricsService {
         const [{ count }] = await txn.find(RowCount, {
           select: ['count'],
           where: {
-            relation: 'canonical_block_header'
-          }
+            relation: 'canonical_block_header',
+          },
         })
 
         const entities = await txn.find(BlockMetricsTransactionFeeEntity, {
           order: { number: 'DESC' },
           skip: offset,
-          take: limit
+          take: limit,
         })
 
         return [entities, count]
@@ -84,7 +84,7 @@ export class BlockMetricsService {
 
   async findBlockMetricsTransactionFeeByBlockHash(blockHash: string): Promise<BlockMetricsTransactionFeeEntity | undefined> {
     return this.entityManager.findOne(BlockMetricsTransactionFeeEntity, {
-      where: { blockHash }
+      where: { blockHash },
     })
   }
 
@@ -121,7 +121,7 @@ export class BlockMetricsService {
     start: Date,
     end: Date,
     bucket: TimeBucket,
-    fields: BlockMetricField[]
+    fields: BlockMetricField[],
   ): Promise<AggregateBlockMetric[]> {
 
     const datapoints = this.estimateDatapoints(start, end, bucket)
@@ -219,7 +219,7 @@ export class BlockMetricsService {
         avgNumFailedTxs: item.avg_num_failed_txs,
         avgNumInternalTxs: item.avg_num_internal_txs,
         avgTxFees: item.avg_tx_fees,
-        avgTotalTxFees: item.avg_total_tx_fees
+        avgTotalTxFees: item.avg_total_tx_fees,
       } as AggregateBlockMetric
 
     })

--- a/apps/api/src/graphql/block-metrics/block-metrics.resolvers.ts
+++ b/apps/api/src/graphql/block-metrics/block-metrics.resolvers.ts
@@ -4,7 +4,7 @@ import {
   BlockMetricField,
   BlockMetricsTransactionFeePage,
   BlockMetricsTransactionPage,
-  TimeBucket
+  TimeBucket,
 } from '@app/graphql/schema'
 import { BlockMetricDto } from '@app/graphql/block-metrics/dto/block-metric.dto'
 import { BlockMetricEntity } from '@app/orm/entities/block-metric.entity'
@@ -30,7 +30,7 @@ export class BlockMetricsResolvers {
   @Query()
   async blockMetricsTransaction(
     @Args('offset') offset: number,
-    @Args('limit') limit: number
+    @Args('limit') limit: number,
   ): Promise<BlockMetricsTransactionPage> {
     const [items, count] = await this.blockMetricsService.findBlockMetricsTransaction(offset, limit)
     return new BlockMetricsTransactionPageDto(offset, limit, items, count)
@@ -39,7 +39,7 @@ export class BlockMetricsResolvers {
   @Query()
   async blockMetricsTransactionFee(
     @Args('offset') offset: number,
-    @Args('limit') limit: number
+    @Args('limit') limit: number,
   ): Promise<BlockMetricsTransactionFeePage> {
     const [items, count] = await this.blockMetricsService.findBlockMetricsTransactionFee(offset, limit)
     return new BlockMetricsTransactionFeePageDto(offset, limit, items, count)
@@ -50,7 +50,7 @@ export class BlockMetricsResolvers {
     @Args('start') start: Date,
     @Args('end') end: Date,
     @Args('bucket') bucket: TimeBucket,
-    @Args({ name: 'fields', type: () => [BlockMetricField] }) fields: BlockMetricField[]
+    @Args({ name: 'fields', type: () => [BlockMetricField] }) fields: BlockMetricField[],
   ): Promise<AggregateBlockMetricDto[]> {
     const entities = await this.blockMetricsService.timeseries(start, end, bucket, fields)
     return entities.map(e => new AggregateBlockMetricDto(e))
@@ -58,7 +58,7 @@ export class BlockMetricsResolvers {
 
   @Subscription(
     'newBlockMetric', {
-      resolve: (summary: BlockMetricEntity) => new BlockMetricDto(summary)
+      resolve: (summary: BlockMetricEntity) => new BlockMetricDto(summary),
     } as SubscriptionOptions)
   newBlockMetric() {
     return this.pubSub.asyncIterator('newBlockMetric')
@@ -66,7 +66,7 @@ export class BlockMetricsResolvers {
 
   @Subscription(
     'newBlockMetricsTransaction', {
-      resolve: (summary: BlockMetricsTransactionEntity) => new BlockMetricsTransactionDto(summary)
+      resolve: (summary: BlockMetricsTransactionEntity) => new BlockMetricsTransactionDto(summary),
     } as SubscriptionOptions)
   newBlockMetricsTransaction() {
     return this.pubSub.asyncIterator('newBlockMetricsTransaction')
@@ -74,7 +74,7 @@ export class BlockMetricsResolvers {
 
   @Subscription(
     'newBlockMetricsTransactionFee', {
-      resolve: (summary: BlockMetricsTransactionFeeEntity) => new BlockMetricsTransactionFeeDto(summary)
+      resolve: (summary: BlockMetricsTransactionFeeEntity) => new BlockMetricsTransactionFeeDto(summary),
     } as SubscriptionOptions)
   newBlockMetricsTransactionFee() {
     return this.pubSub.asyncIterator('newBlockMetricsTransactionFee')

--- a/apps/api/src/graphql/block-metrics/dto/block-metrics-transaction-fee-page.dto.ts
+++ b/apps/api/src/graphql/block-metrics/dto/block-metrics-transaction-fee-page.dto.ts
@@ -1,4 +1,3 @@
-import { BlockMetricDto } from '@app/graphql/block-metrics/dto/block-metric.dto'
 import { BlockMetricsTransactionFeePage } from '@app/graphql/schema'
 import { BlockMetricsTransactionFeeDto } from '@app/graphql/block-metrics/dto/block-metrics-transaction-fee.dto'
 import { BlockMetricsTransactionFeeEntity } from '@app/orm/entities/block-metrics-transaction-fee.entity'
@@ -13,7 +12,7 @@ export class BlockMetricsTransactionFeePageDto implements BlockMetricsTransactio
   constructor(offset: number, limit: number, items: BlockMetricsTransactionFeeEntity[], totalCount: number) {
     this.offset = offset
     this.limit = limit
-    this.items = items.map(i => new BlockMetricDto(i))
+    this.items = items.map(i => new BlockMetricsTransactionFeeDto(i))
     this.totalCount = totalCount
   }
 

--- a/apps/api/src/graphql/block-metrics/dto/block-metrics-transaction-page.dto.ts
+++ b/apps/api/src/graphql/block-metrics/dto/block-metrics-transaction-page.dto.ts
@@ -1,4 +1,3 @@
-import { BlockMetricDto } from '@app/graphql/block-metrics/dto/block-metric.dto'
 import { BlockMetricsTransactionDto } from '@app/graphql/block-metrics/dto/block-metrics-transaction.dto'
 import { BlockMetricsTransactionPage } from '@app/graphql/schema'
 import { BlockMetricsTransactionEntity } from '@app/orm/entities/block-metrics-transaction.entity'
@@ -13,7 +12,7 @@ export class BlockMetricsTransactionPageDto implements BlockMetricsTransactionPa
   constructor(offset: number, limit: number, items: BlockMetricsTransactionEntity[], totalCount: number) {
     this.offset = offset
     this.limit = limit
-    this.items = items.map(i => new BlockMetricDto(i))
+    this.items = items.map(i => new BlockMetricsTransactionDto(i))
     this.totalCount = totalCount
   }
 

--- a/apps/api/src/subscriptions/pg-subscription.service.ts
+++ b/apps/api/src/subscriptions/pg-subscription.service.ts
@@ -79,7 +79,7 @@ function inputIsPgEvent(input: any): input is PgEvent {
 // tslint:disable-next-line:no-shadowed-variable
 function isPgEvent<PgEvent>() {
   return (source$: Observable<any>) => source$.pipe(
-    filter(inputIsPgEvent)
+    filter(inputIsPgEvent),
   )
 }
 
@@ -87,12 +87,12 @@ function isPgEvent<PgEvent>() {
 function isMetadataEvent<PgEvent>() {
 
   const tables = new Set<string>([
-    'metadata'
+    'metadata',
   ])
 
   return (source$: Observable<any>) => source$.pipe(
     filter(inputIsPgEvent),
-    filter(e => tables.has(e.table))
+    filter(e => tables.has(e.table)),
   )
 }
 
@@ -103,12 +103,12 @@ function isBlockEvent<PgEvent>() {
     'canonical_block_header',
     'transaction',
     'transaction_trace',
-    'transaction_receipt'
+    'transaction_receipt',
   ])
 
   return (source$: Observable<any>) => source$.pipe(
     filter(inputIsPgEvent),
-    filter(e => tables.has(e.table))
+    filter(e => tables.has(e.table)),
   )
 }
 
@@ -116,7 +116,7 @@ function isBlockEvent<PgEvent>() {
 function isBlockMetricsTransactionEvent<PgEvent>() {
   return (source$: Observable<any>) => source$.pipe(
     filter(inputIsPgEvent),
-    filter(e => e.table === 'block_metrics_transaction')
+    filter(e => e.table === 'block_metrics_transaction'),
   )
 }
 
@@ -124,7 +124,7 @@ function isBlockMetricsTransactionEvent<PgEvent>() {
 function isBlockMetricsTransactionFeeEvent<PgEvent>() {
   return (source$: Observable<any>) => source$.pipe(
     filter(inputIsPgEvent),
-    filter(e => e.table === 'block_metrics_transaction_fee')
+    filter(e => e.table === 'block_metrics_transaction_fee'),
   )
 }
 
@@ -180,7 +180,7 @@ export class PgSubscriptionService {
     private readonly config: ConfigService,
     private readonly blockService: BlockService,
     private readonly transactionService: TxService,
-    private readonly blockMetricsService: BlockMetricsService
+    private readonly blockMetricsService: BlockMetricsService,
   ) {
 
     this.url = config.db.url
@@ -221,7 +221,7 @@ export class PgSubscriptionService {
     const pgEvents$ = events$
       .pipe(
         map(event => new PgEvent(event)),
-        isPgEvent()
+        isPgEvent(),
       )
 
     //
@@ -250,7 +250,7 @@ export class PgSubscriptionService {
     blockHashes$
       .pipe(
         bufferTime(100),
-        filter(blockHashes => blockHashes.length > 0)
+        filter(blockHashes => blockHashes.length > 0),
       )
       .subscribe(async blockHashes => {
 
@@ -275,7 +275,7 @@ export class PgSubscriptionService {
     blockMetrics$
       .pipe(
         bufferTime(100),
-        filter(blockHashes => blockHashes.length > 0)
+        filter(blockHashes => blockHashes.length > 0),
       )
       .subscribe(async blockHashes => {
         const metrics = await blockMetricsService.findByBlockHash(blockHashes)

--- a/apps/explorer/src/modules/charts/components/live/ChartLiveTxFees.vue
+++ b/apps/explorer/src/modules/charts/components/live/ChartLiveTxFees.vue
@@ -44,11 +44,10 @@ class ChartData {
     return {
       syncing: undefined,
       avgGasPrices: undefined,
-      avgTxFees: undefined,
+      avgTxFees: undefined
     }
   },
   apollo: {
-
     avgGasPrices: {
       query: latestAvgGasPrices,
 
@@ -89,11 +88,9 @@ class ChartData {
       },
 
       subscribeToMore: {
-
         document: newAvgGasPrice,
 
         updateQuery: (previousResult, { subscriptionData }) => {
-
           const { blockMetricsTransaction } = previousResult
           const { newBlockMetricsTransaction } = subscriptionData.data
 
@@ -103,9 +100,9 @@ class ChartData {
 
           items.unshift(newBlockMetricsTransaction)
 
-            if (items.length > MAX_ITEMS) {
-              items.pop()
-            }
+          if (items.length > MAX_ITEMS) {
+            items.pop()
+          }
 
           // ensure order by block number desc
           items.sort((a, b) => {
@@ -165,11 +162,9 @@ class ChartData {
       },
 
       subscribeToMore: {
-
         document: newAvgTxFee,
 
         updateQuery: (previousResult, { subscriptionData }) => {
-
           const { blockMetricsTransactionFee } = previousResult
           const { newBlockMetricsTransactionFee } = subscriptionData.data
 
@@ -248,42 +243,41 @@ export default class ChartLiveTxFees extends Vue {
     */
 
   toChartData(avgGasPrices?: latestAvgGasPrices_blockMetricsTransaction, avgTxFees?: latestAvgTxFees_blockMetricsTransactionFee) {
-
     const numberLabel = this.$i18n.t('block.number')
 
     const labels: string[] = []
     const avgFees: number[] = []
     const avgPrice: number[] = []
 
-    if(!(avgGasPrices && avgTxFees)) return new ChartData(labels, avgFees, avgPrice)
+    if (!(avgGasPrices && avgTxFees)) {
+      return new ChartData(labels, avgFees, avgPrice)
+    }
 
-    if(!(avgGasPrices!.items.length && avgTxFees!.items.length)) return new ChartData(labels, avgFees, avgPrice)
+    if (!(avgGasPrices!.items.length && avgTxFees!.items.length)) {
+      return new ChartData(labels, avgFees, avgPrice)
+    }
 
     const gasPriceItems = avgGasPrices!.items
     const txFeeItems = avgTxFees!.items
 
-    if(gasPriceItems.length && txFeeItems.length) {
-
+    if (gasPriceItems.length && txFeeItems.length) {
       const numbers = new Set<number>()
       gasPriceItems.forEach(item => numbers.add(item.number))
       txFeeItems.forEach(item => numbers.add(item.number))
 
       const numbersDesc = Array.from(numbers).sort((a, b) => b - a)
 
-      const gasPricesByNumber = gasPriceItems
-        .reduce((memo, next) => {
-          memo.set(parseInt(next.number)!, new EthValue(next.avgGasPrice!).toGWei())
-          return memo
-        }, new Map<number, number>())
+      const gasPricesByNumber = gasPriceItems.reduce((memo, next) => {
+        memo.set(parseInt(next.number)!, new EthValue(next.avgGasPrice!).toGWei())
+        return memo
+      }, new Map<number, number>())
 
-      const txFeesByNumber = txFeeItems
-        .reduce((memo, next) => {
-          memo.set(parseInt(next.number), new EthValue(next.avgTxFees!).toGWei())
-          return memo
-        }, new Map<number, number>())
+      const txFeesByNumber = txFeeItems.reduce((memo, next) => {
+        memo.set(parseInt(next.number), new EthValue(next.avgTxFees!).toGWei())
+        return memo
+      }, new Map<number, number>())
 
       numbersDesc.forEach(number => {
-
         // for some reasons number is a string
         const avgGasPrice = gasPricesByNumber.get(+number) || 0
         const avgTxFee = txFeesByNumber.get(+number) || 0
@@ -291,9 +285,7 @@ export default class ChartLiveTxFees extends Vue {
         labels.push(numberLabel + number.toString())
         avgPrice.push(avgGasPrice)
         avgFees.push(avgTxFee)
-
       })
-
     }
 
     return new ChartData(labels, avgFees, avgPrice)
@@ -310,7 +302,6 @@ export default class ChartLiveTxFees extends Vue {
   }
 
   get chartData() {
-
     const data = this.toChartData(this.avgGasPrices, this.avgTxFees)
 
     return {


### PR DESCRIPTION
- block-metrics.resolvers.ts was updated without updating the unit tests causing travis checks to fail. They have now been updated.
- BlockMetricsTransactionsPageDto and BlockMetricsTransactionFeesPageDto are now correctly converting items arrays to BlockMetricsTransactionDto and BlockMetricsTransactionFeeDto respectively. 