### PR TITLE
Feature/token exchange rates and metadata by name

### DIFF
--- a/apps/api/src/dao/dao.module.ts
+++ b/apps/api/src/dao/dao.module.ts
@@ -30,6 +30,7 @@ import {TxService} from '@app/dao/tx.service'
 import {BlockMetricEntity} from '@app/orm/entities/block-metric.entity'
 import { MetadataEntity } from '@app/orm/entities/metadata.entity'
 import { MetadataService } from '@app/dao/metadata.service'
+import { TokenMetadataEntity } from '@app/orm/entities/token-metadata.entity'
 
 @Module({
   imports: [
@@ -52,6 +53,7 @@ import { MetadataService } from '@app/dao/metadata.service'
       CoinExchangeRateEntity,
       BlockMetricEntity,
       MetadataEntity,
+      TokenMetadataEntity,
     ]),
   ],
   providers: [

--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -191,7 +191,7 @@ export class TokenService {
     addresses: string[] = [],
     offset: number = 0,
     limit: number = 20,
-  ): Promise<TokenMetadataEntity[]> {
+  ): Promise<[TokenMetadataEntity[], number]> {
     const where: any[] = []
     if (symbols.length) {
       where.push({ symbol: Any(symbols) })
@@ -207,6 +207,6 @@ export class TokenService {
       take: limit,
       skip: offset,
     }
-    return await this.tokenMetadataRepository.find(findOptions)
+    return await this.tokenMetadataRepository.findAndCount(findOptions)
   }
 }

--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -185,8 +185,28 @@ export class TokenService {
 
   }
 
-  async findTokensMetadata(symbols: string[] = []): Promise<TokenMetadataEntity[]> {
-    const where = symbols.length > 0 ? { symbol: Any(symbols) } : {}
-    return await this.tokenMetadataRepository.find({ where })
+  async findTokensMetadata(
+    symbols: string[] = [],
+    names: string[] = [],
+    addresses: string[] = [],
+    offset: number = 0,
+    limit: number = 20
+  ): Promise<TokenMetadataEntity[]> {
+    let where: any[] = []
+    if (symbols.length) {
+      where.push({ symbol: Any(symbols) })
+    }
+    if (names.length) {
+      where.push({ name: Any(names) })
+    }
+    if (addresses.length) {
+      where.push({ address: Any(addresses) })
+    }
+    const findOptions = {
+      where,
+      take: limit,
+      skip: offset
+    }
+    return await this.tokenMetadataRepository.find(findOptions)
   }
 }

--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -101,7 +101,7 @@ export class TokenService {
     offset: number = 0,
     symbols: string[] = [],
     names: string[] = [],
-    addresses: string[] = []
+    addresses: string[] = [],
   ): Promise<[TokenExchangeRateEntity[], number]> {
     let order
     switch (sort) {
@@ -129,7 +129,7 @@ export class TokenService {
         break
     }
 
-    let where = [] as any[]
+    const where = [] as any[]
     if (symbols.length) {
       where.push({symbol: Any(symbols)})
     }
@@ -190,9 +190,9 @@ export class TokenService {
     names: string[] = [],
     addresses: string[] = [],
     offset: number = 0,
-    limit: number = 20
+    limit: number = 20,
   ): Promise<TokenMetadataEntity[]> {
-    let where: any[] = []
+    const where: any[] = []
     if (symbols.length) {
       where.push({ symbol: Any(symbols) })
     }
@@ -205,7 +205,7 @@ export class TokenService {
     const findOptions = {
       where,
       take: limit,
-      skip: offset
+      skip: offset,
     }
     return await this.tokenMetadataRepository.find(findOptions)
   }

--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -115,7 +115,14 @@ export class TokenService {
     return this.coinExchangeRateRepository.findOne(findOptions)
   }
 
-  async findTokenExchangeRates(sort: string, limit: number = 10, offset: number = 0, symbols: string[] = []): Promise<[TokenExchangeRateEntity[], number]> {
+  async findTokenExchangeRates(
+    sort: string,
+    limit: number = 10,
+    offset: number = 0,
+    symbols: string[] = [],
+    names: string[] = [],
+    addresses: string[] = []
+  ): Promise<[TokenExchangeRateEntity[], number]> {
     let order
     switch (sort) {
       case 'price_high':
@@ -141,7 +148,18 @@ export class TokenService {
         order = { marketCapRank: 1 }
         break
     }
-    const where = symbols.length > 0 ? { symbol: Any(symbols) } : {}
+
+    let where = [] as any[]
+    if (symbols.length) {
+      where.push({symbol: Any(symbols)})
+    }
+    if (names.length) {
+      where.push({name: Any(names)})
+    }
+    if (addresses.length) {
+      where.push({address: Any(addresses)})
+    }
+
     const findOptions: FindManyOptions = {
       where,
       order,

--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -96,7 +96,7 @@ export class TokenService {
   }
 
   async findTokenExchangeRates(
-    sort: string,
+    sort: string = 'market_cap_rank',
     limit: number = 10,
     offset: number = 0,
     symbols: string[] = [],

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -338,7 +338,7 @@ export interface IQuery {
     totalNumTokenExchangeRates(): number | Promise<number>;
     tokenExchangeRateBySymbol(symbol: string): TokenExchangeRate | Promise<TokenExchangeRate>;
     tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
-    tokensMetadata(symbols?: string[], names?: string[], addresses?: string[], offset?: number, limit?: number): TokenMetadata[] | Promise<TokenMetadata[]>;
+    tokensMetadata(symbols?: string[], names?: string[], addresses?: string[], offset?: number, limit?: number): TokenMetadataPage | Promise<TokenMetadataPage>;
     tokenHolders(address: string, offset?: number, limit?: number): TokenHoldersPage | Promise<TokenHoldersPage>;
     tokenTransfersByContractAddressesForHolder(contractAddresses: string[], holderAddress: string, filter?: FilterEnum, limit?: number, page?: number, timestampFrom?: number, timestampTo?: number): TransferPage | Promise<TransferPage>;
     internalTransactionsByAddress(address: string, offset?: number, limit?: number): TransferPage | Promise<TransferPage>;
@@ -455,6 +455,11 @@ export interface TokenMetadata {
     address?: string;
     decimals?: number;
     logo?: string;
+}
+
+export interface TokenMetadataPage {
+    items: TokenMetadata[];
+    totalCount: number;
 }
 
 export interface TokenPage {

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -334,7 +334,7 @@ export interface IQuery {
     addressAllTokensOwned(address: string, offset?: number, limit?: number): TokenPage | Promise<TokenPage>;
     addressTotalTokenValueUSD(address: string): BigNumber | Promise<BigNumber>;
     coinExchangeRate(pair: ExchangeRatePair): CoinExchangeRate | Promise<CoinExchangeRate>;
-    tokenExchangeRates(symbols: string[], sort?: TokenExchangeRateFilter, offset?: number, limit?: number): TokenExchangeRatesPage | Promise<TokenExchangeRatesPage>;
+    tokenExchangeRates(symbols?: string[], names?: string[], addresses?: string[], sort?: TokenExchangeRateFilter, offset?: number, limit?: number): TokenExchangeRatesPage | Promise<TokenExchangeRatesPage>;
     totalNumTokenExchangeRates(): number | Promise<number>;
     tokenExchangeRateBySymbol(symbol: string): TokenExchangeRate | Promise<TokenExchangeRate>;
     tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -338,7 +338,7 @@ export interface IQuery {
     totalNumTokenExchangeRates(): number | Promise<number>;
     tokenExchangeRateBySymbol(symbol: string): TokenExchangeRate | Promise<TokenExchangeRate>;
     tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
-    tokensMetadata(symbols?: string[]): TokenMetadata[] | Promise<TokenMetadata[]>;
+    tokensMetadata(symbols?: string[], names?: string[], addresses?: string[], offset?: number, limit?: number): TokenMetadata[] | Promise<TokenMetadata[]>;
     tokenHolders(address: string, offset?: number, limit?: number): TokenHoldersPage | Promise<TokenHoldersPage>;
     tokenTransfersByContractAddressesForHolder(contractAddresses: string[], holderAddress: string, filter?: FilterEnum, limit?: number, page?: number, timestampFrom?: number, timestampTo?: number): TransferPage | Promise<TransferPage>;
     internalTransactionsByAddress(address: string, offset?: number, limit?: number): TransferPage | Promise<TransferPage>;

--- a/apps/api/src/graphql/tokens/dto/token-metadata-page.dto.ts
+++ b/apps/api/src/graphql/tokens/dto/token-metadata-page.dto.ts
@@ -1,0 +1,16 @@
+import { TokenMetadata, TokenMetadataPage } from '@app/graphql/schema'
+import { assignClean } from '@app/shared/utils'
+import { TokenMetadataDto } from '@app/graphql/tokens/dto/token-metadata.dto'
+
+export class TokenMetadataPageDto implements TokenMetadataPage {
+  items!: TokenMetadata[]
+  totalCount!: number
+
+  constructor(data) {
+    if (data.items) {
+      this.items = data.items.map(i => new TokenMetadataDto(i))
+      delete data.items
+    }
+    assignClean(this, data)
+  }
+}

--- a/apps/api/src/graphql/tokens/dto/token-metadata.dto.ts
+++ b/apps/api/src/graphql/tokens/dto/token-metadata.dto.ts
@@ -1,5 +1,6 @@
 import { TokenMetadata } from '@app/graphql/schema'
 import { assignClean } from '@app/shared/utils'
+import { TokenMetadataEntity } from '@app/orm/entities/token-metadata.entity'
 
 export class TokenMetadataDto implements TokenMetadata {
 
@@ -11,8 +12,10 @@ export class TokenMetadataDto implements TokenMetadata {
   decimals?: number
   logo?: string
 
-  constructor(data: any) {
+  constructor(data: TokenMetadataEntity) {
     assignClean(this, data)
+    this.email = data.support ? JSON.parse(data.support).email : null
+    this.logo = data.logo ? JSON.parse(data.logo).src : null
   }
 
 }

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -3,7 +3,7 @@ type Query {
   addressAllTokensOwned(address: String!, offset: Int = 0, limit: Int = 10): TokenPage!
   addressTotalTokenValueUSD(address: String!): BigNumber
   coinExchangeRate(pair: ExchangeRatePair!): CoinExchangeRate
-  tokenExchangeRates(symbols: [String!], sort: TokenExchangeRateFilter, offset: Int = 0, limit: Int = 20): TokenExchangeRatesPage!
+  tokenExchangeRates(symbols: [String], names: [String], addresses: [String], sort: TokenExchangeRateFilter, offset: Int = 0, limit: Int = 20): TokenExchangeRatesPage!
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
   tokenExchangeRateByAddress(address: String!): TokenExchangeRate

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -7,7 +7,7 @@ type Query {
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
   tokenExchangeRateByAddress(address: String!): TokenExchangeRate
-  tokensMetadata(symbols: [String], names: [String], addresses: [String], offset: Int = 0, limit: Int = 20): [TokenMetadata!]!
+  tokensMetadata(symbols: [String], names: [String], addresses: [String], offset: Int = 0, limit: Int = 20): TokenMetadataPage!
   tokenHolders(address: String!, offset: Int = 0, limit: Int = 20): TokenHoldersPage!
 }
 
@@ -83,6 +83,11 @@ type TokenMetadata {
   address: String
   decimals: Int
   logo: String
+}
+
+type TokenMetadataPage {
+  items: [TokenMetadata!]!
+  totalCount: Int!
 }
 
 enum ExchangeRatePair {

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -7,7 +7,7 @@ type Query {
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
   tokenExchangeRateByAddress(address: String!): TokenExchangeRate
-  tokensMetadata(symbols: [String]): [TokenMetadata!]!
+  tokensMetadata(symbols: [String], names: [String], addresses: [String], offset: Int = 0, limit: Int = 20): [TokenMetadata!]!
   tokenHolders(address: String!, offset: Int = 0, limit: Int = 20): TokenHoldersPage!
 }
 

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -96,8 +96,14 @@ export class TokenResolvers {
   }
 
   @Query()
-  async tokensMetadata(@Args({name: 'symbols', type: () => [String]}) symbols: string[]): Promise<TokenMetadataDto[]> {
-    const entities = await this.tokenService.findTokensMetadata(symbols)
+  async tokensMetadata(
+    @Args({ name: 'symbols', type: () => [String] }) symbols: string[],
+    @Args({ name: 'names', type: () => [String] }) names: string[],
+    @Args({ name: 'addresses', type: () => [String] }) addresses: string[],
+    @Args('offset') offset: number,
+    @Args('limit') limit: number,
+  ): Promise<TokenMetadataDto[]> {
+    const entities = await this.tokenService.findTokensMetadata(symbols, names, addresses, offset, limit)
     return entities.map(e => new TokenMetadataDto(e))
   }
 }

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -66,11 +66,13 @@ export class TokenResolvers {
   @Query()
   async tokenExchangeRates(
     @Args({ name: 'symbols', type: () => [String] }) symbols: string[],
+    @Args({ name: 'names', type: () => [String] }) names: string[],
+    @Args({ name: 'addresses', type: () => [String] }) addresses: string[],
     @Args('sort') sort: string,
     @Args('limit') limit: number,
     @Args('offset') offset: number,
   ): Promise<TokenExchangeRatePageDto> {
-    const [items, totalCount] = await this.tokenService.findTokenExchangeRates(sort, limit, offset, symbols)
+    const [items, totalCount] = await this.tokenService.findTokenExchangeRates(sort, limit, offset, symbols, names, addresses)
     return new TokenExchangeRatePageDto({ items, totalCount })
   }
 

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -97,6 +97,7 @@ export class TokenResolvers {
 
   @Query()
   async tokensMetadata(@Args({name: 'symbols', type: () => [String]}) symbols: string[]): Promise<TokenMetadataDto[]> {
-    return await this.tokenService.findTokensMetadata(symbols)
+    const entities = await this.tokenService.findTokensMetadata(symbols)
+    return entities.map(e => new TokenMetadataDto(e))
   }
 }

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -65,12 +65,12 @@ export class TokenResolvers {
 
   @Query()
   async tokenExchangeRates(
-    @Args({ name: 'symbols', type: () => [String] }) symbols: string[],
-    @Args({ name: 'names', type: () => [String] }) names: string[],
-    @Args({ name: 'addresses', type: () => [String] }) addresses: string[],
-    @Args('sort') sort: string,
-    @Args('limit') limit: number,
-    @Args('offset') offset: number,
+    @Args({ name: 'symbols', type: () => [String], nullable: true }) symbols?: string[],
+    @Args({ name: 'names', type: () => [String], nullable: true }) names?: string[],
+    @Args({ name: 'addresses', type: () => [String], nullable: true }) addresses?: string[],
+    @Args('sort') sort?: string,
+    @Args('limit') limit?: number,
+    @Args('offset') offset?: number,
   ): Promise<TokenExchangeRatePageDto> {
     const [items, totalCount] = await this.tokenService.findTokenExchangeRates(sort, limit, offset, symbols, names, addresses)
     return new TokenExchangeRatePageDto({ items, totalCount })
@@ -97,11 +97,11 @@ export class TokenResolvers {
 
   @Query()
   async tokensMetadata(
-    @Args({ name: 'symbols', type: () => [String] }) symbols: string[],
-    @Args({ name: 'names', type: () => [String] }) names: string[],
-    @Args({ name: 'addresses', type: () => [String] }) addresses: string[],
-    @Args('offset') offset: number,
-    @Args('limit') limit: number,
+    @Args({ name: 'symbols', type: () => [String], nullable: true }) symbols?: string[],
+    @Args({ name: 'names', type: () => [String], nullable: true }) names?: string[],
+    @Args({ name: 'addresses', type: () => [String], nullable: true }) addresses?: string[],
+    @Args('offset') offset?: number,
+    @Args('limit') limit?: number,
   ): Promise<TokenMetadataDto[]> {
     const entities = await this.tokenService.findTokensMetadata(symbols, names, addresses, offset, limit)
     return entities.map(e => new TokenMetadataDto(e))

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -11,6 +11,7 @@ import { TokenExchangeRatePageDto } from '@app/graphql/tokens/dto/token-exchange
 import { CoinExchangeRateDto } from '@app/graphql/tokens/dto/coin-exchange-rate.dto'
 import { UseInterceptors } from '@nestjs/common'
 import { SyncingInterceptor } from '@app/shared/interceptors/syncing-interceptor'
+import { TokenMetadataPageDto } from '@app/graphql/tokens/dto/token-metadata-page.dto'
 
 @Resolver('Token')
 @UseInterceptors(SyncingInterceptor)
@@ -102,8 +103,8 @@ export class TokenResolvers {
     @Args({ name: 'addresses', type: () => [String], nullable: true }) addresses?: string[],
     @Args('offset') offset?: number,
     @Args('limit') limit?: number,
-  ): Promise<TokenMetadataDto[]> {
-    const entities = await this.tokenService.findTokensMetadata(symbols, names, addresses, offset, limit)
-    return entities.map(e => new TokenMetadataDto(e))
+  ): Promise<TokenMetadataPageDto> {
+    const [items, totalCount] = await this.tokenService.findTokensMetadata(symbols, names, addresses, offset, limit)
+    return new TokenMetadataPageDto({ items, totalCount })
   }
 }

--- a/apps/api/src/orm/entities/token-metadata.entity.ts
+++ b/apps/api/src/orm/entities/token-metadata.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm'
+import { assignClean } from '@app/shared/utils'
+
+@Entity('token_metadata')
+export class TokenMetadataEntity {
+
+  constructor(data: any) {
+    assignClean(this, data);
+  }
+
+  @PrimaryColumn({ type: 'character varying', readonly: true })
+  address!: string
+
+  @Column({ type: 'character varying', readonly: true })
+  name?: string
+
+  @Column({ type: 'character varying', readonly: true })
+  symbol?: string
+
+  @Column({ type: 'character varying', readonly: true })
+  website?: string
+
+  @Column({ type: 'text', readonly: true })
+  logo?: string
+
+  @Column({ type: 'text', readonly: true })
+  support?: string
+
+  @Column({ type: 'integer', readonly: true })
+  decimals?: string
+
+}

--- a/apps/migrator/sql/V2__Add_token_views.sql
+++ b/apps/migrator/sql/V2__Add_token_views.sql
@@ -1,0 +1,26 @@
+CREATE INDEX idx_token_exchange_rates__name ON token_exchange_rates (name);
+CREATE INDEX idx_token_exchange_rates__symbol ON token_exchange_rates (symbol);
+
+/* create token_search_result view for sorting erc20 and erc721 tokens matching a query string */
+CREATE VIEW token_metadata AS
+SELECT  e20.name AS name,
+        e20.symbol AS symbol,
+        e20.address AS address,
+        e20.decimals AS decimals,
+        elcm.website AS website,
+        elcm.logo AS logo,
+        elcm.support AS support,
+        'erc20' AS type
+FROM erc20_metadata AS e20
+        LEFT JOIN eth_list_contract_metadata AS elcm ON elcm.address = e20.address
+UNION ALL
+SELECT  e721.name,
+        e721.symbol,
+        e721.address,
+        NULL,
+        elcm2.website,
+        elcm2.logo,
+        elcm2.support,
+        'erc721' AS type
+FROM erc721_metadata AS e721
+        LEFT JOIN eth_list_contract_metadata AS elcm2 ON elcm2.address = e721.address;


### PR DESCRIPTION
This PR enhances tokensMetadata and tokenExchangeRates queries to allow filtering by "names" or "addresses" params in addition to "symbols". It also adds paging to tokensMetadata query.

In order to improve tokensMetadata, I added a new view "token_metadata" which combines both erc20_metadata and erc721_metadata tables. This allows only one query to be performed, as well as paging and sorting.