### PR TITLE
Fix/conditionally show internal transfers tab

### DIFF
--- a/apps/api/src/dao/account.service.ts
+++ b/apps/api/src/dao/account.service.ts
@@ -57,7 +57,7 @@ export class AccountService {
 
     const transfer = await this.transferRepository.findOne({
       where: [{ to: address, deltaType: In(deltaTypes) }, { from: address, deltaType: In(deltaTypes) }],
-      cache: true
+      cache: true,
     })
 
     return !!transfer;

--- a/apps/api/src/graphql/accounts/account.dto.ts
+++ b/apps/api/src/graphql/accounts/account.dto.ts
@@ -12,6 +12,7 @@ export class AccountDto implements Account {
   outTxCount!: BigNumber
   totalTxCount!: BigNumber
   isContract!: boolean
+  hasInternalTransfers!: boolean
 
   constructor(data: any) {
     assignClean(this, data)

--- a/apps/api/src/graphql/accounts/account.graphql
+++ b/apps/api/src/graphql/accounts/account.graphql
@@ -11,4 +11,5 @@ type Account {
   isMiner: Boolean!
   isContractCreator: Boolean!
   isContract: Boolean!
+  hasInternalTransfers: Boolean!
 }

--- a/apps/api/src/graphql/accounts/account.resolvers.spec.ts
+++ b/apps/api/src/graphql/accounts/account.resolvers.spec.ts
@@ -35,6 +35,9 @@ const accountServiceMock = {
   },
   async findIsContractCreator(address: string) {
     return false
+  },
+  async findHasInternalTransfers(address: string) {
+    return false
   }
 }
 
@@ -95,7 +98,8 @@ describe('AccountResolvers', () => {
         new AccountDto({
           address: address1,
           isContractCreator: false,
-          isMiner: false
+          isMiner: false,
+          hasInternalTransfers: false
         })
       )
     })

--- a/apps/api/src/graphql/accounts/account.resolvers.ts
+++ b/apps/api/src/graphql/accounts/account.resolvers.ts
@@ -15,7 +15,8 @@ export class AccountResolvers {
     const account = await this.accountService.findAccountByAddress(address)
     const isMiner = await this.accountService.findIsMiner(address)
     const isContractCreator = await this.accountService.findIsContractCreator(address)
-    return account ? new AccountDto({ ...account, isMiner, isContractCreator }) : null
+    const hasInternalTransfers = await this.accountService.findHasInternalTransfers(address)
+    return account ? new AccountDto({ ...account, isMiner, isContractCreator, hasInternalTransfers }) : null
   }
 
 }

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -318,15 +318,15 @@ export interface Metadata {
 }
 
 export interface IQuery {
-    accountByAddress(address: string): Account | Promise<Account>;
-    blockMetricsTransaction(offset?: number, limit?: number): BlockMetricsTransactionPage | Promise<BlockMetricsTransactionPage>;
-    blockMetricsTransactionFee(offset?: number, limit?: number): BlockMetricsTransactionFeePage | Promise<BlockMetricsTransactionFeePage>;
-    blockMetricsTimeseries(start: Date, end: Date, bucket: TimeBucket, fields: BlockMetricField[]): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
     hashRate(): BigNumber | Promise<BigNumber>;
     blockSummaries(fromBlock?: BigNumber, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;
     blockSummariesByAuthor(author: string, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;
     blockByHash(hash: string): Block | Promise<Block>;
     blockByNumber(number: BigNumber): Block | Promise<Block>;
+    accountByAddress(address: string): Account | Promise<Account>;
+    blockMetricsTransaction(offset?: number, limit?: number): BlockMetricsTransactionPage | Promise<BlockMetricsTransactionPage>;
+    blockMetricsTransactionFee(offset?: number, limit?: number): BlockMetricsTransactionFeePage | Promise<BlockMetricsTransactionFeePage>;
+    blockMetricsTimeseries(start: Date, end: Date, bucket: TimeBucket, fields: BlockMetricField[]): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
     contractByAddress(address: string): Contract | Promise<Contract>;
     contractsCreatedBy(creator: string, offset?: number, limit?: number): ContractSummaryPage | Promise<ContractSummaryPage>;
     metadata(): Metadata | Promise<Metadata>;
@@ -389,11 +389,11 @@ export interface Search {
 }
 
 export interface ISubscription {
+    newBlock(): BlockSummary | Promise<BlockSummary>;
+    hashRate(): BigNumber | Promise<BigNumber>;
     newBlockMetric(): BlockMetric | Promise<BlockMetric>;
     newBlockMetricsTransaction(): BlockMetricsTransaction | Promise<BlockMetricsTransaction>;
     newBlockMetricsTransactionFee(): BlockMetricsTransactionFee | Promise<BlockMetricsTransactionFee>;
-    newBlock(): BlockSummary | Promise<BlockSummary>;
-    hashRate(): BigNumber | Promise<BigNumber>;
     isSyncing(): boolean | Promise<boolean>;
     newTransaction(): TransactionSummary | Promise<TransactionSummary>;
 }

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -89,6 +89,7 @@ export interface Account {
     isMiner: boolean;
     isContractCreator: boolean;
     isContract: boolean;
+    hasInternalTransfers: boolean;
 }
 
 export interface AddressBalance {

--- a/apps/explorer/apollo/schemas/api.json
+++ b/apps/explorer/apollo/schemas/api.json
@@ -1691,6 +1691,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "hasInternalTransfers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/apps/explorer/src/core/api/apollo/extensions/account.ext.ts
+++ b/apps/explorer/src/core/api/apollo/extensions/account.ext.ts
@@ -12,6 +12,7 @@ export class AccountExt implements Account {
   isMiner: boolean
   outTxCount: any
   totalTxCount: any
+  hasInternalTransfers: boolean
 
   constructor(proto: Account) {
     this.address = proto.address
@@ -22,6 +23,7 @@ export class AccountExt implements Account {
     this.isMiner = proto.isMiner
     this.outTxCount = proto.outTxCount
     this.totalTxCount = proto.totalTxCount
+    this.hasInternalTransfers = proto.hasInternalTransfers
   }
 
   get balanceBN(): BigNumber {

--- a/apps/explorer/src/core/api/apollo/types/Account.ts
+++ b/apps/explorer/src/core/api/apollo/types/Account.ts
@@ -16,4 +16,5 @@ export interface Account {
   isMiner: boolean;
   isContractCreator: boolean;
   isContract: boolean;
+  hasInternalTransfers: boolean;
 }

--- a/apps/explorer/src/core/api/apollo/types/addressDetail.ts
+++ b/apps/explorer/src/core/api/apollo/types/addressDetail.ts
@@ -16,6 +16,7 @@ export interface addressDetail_account {
   isMiner: boolean;
   isContractCreator: boolean;
   isContract: boolean;
+  hasInternalTransfers: boolean;
 }
 
 export interface addressDetail {

--- a/apps/explorer/src/modules/addresses/addresses.graphql
+++ b/apps/explorer/src/modules/addresses/addresses.graphql
@@ -59,6 +59,7 @@ fragment Account on Account {
   isMiner
   isContractCreator
   isContract
+  hasInternalTransfers
 }
 
 query exchangeRate {

--- a/apps/explorer/src/modules/addresses/pages/PageDetailsAddress.vue
+++ b/apps/explorer/src/modules/addresses/pages/PageDetailsAddress.vue
@@ -213,7 +213,7 @@ export default class PageDetailsAddress extends Vue {
         id: 1,
         title: this.$i18n.tc('token.name', 2),
         isActive: false
-      },
+      }
       // {
       //   id: 2,
       //   title: this.$i18n.tc('tx.pending', 2),
@@ -222,7 +222,6 @@ export default class PageDetailsAddress extends Vue {
     ]
 
     if (!this.loading && !this.error && this.account) {
-
       if (this.account.hasInternalTransfers) {
         const newTab = {
           id: 5,

--- a/apps/explorer/src/modules/addresses/pages/PageDetailsAddress.vue
+++ b/apps/explorer/src/modules/addresses/pages/PageDetailsAddress.vue
@@ -48,7 +48,7 @@
         INTERNAL TRANSFERS TAB
       =====================================================================================
       -->
-      <v-tab-item slot="tabs-item" value="tab-5">
+      <v-tab-item v-if="account.hasInternalTransfers" slot="tabs-item" value="tab-5">
         <transfers-table :address="addressRef" :page-type="'internal'" />
       </v-tab-item>
       <!--
@@ -218,15 +218,20 @@ export default class PageDetailsAddress extends Vue {
       //   id: 2,
       //   title: this.$i18n.tc('tx.pending', 2),
       //   isActive: false
-      // },
-      {
-        id: 5,
-        title: this.$i18n.tc('transfer.internal', 2),
-        isActive: false
-      }
+      // }
     ]
 
     if (!this.loading && !this.error && this.account) {
+
+      if (this.account.hasInternalTransfers) {
+        const newTab = {
+          id: 5,
+          title: this.$i18n.tc('transfer.internal', 2),
+          isActive: false
+        }
+        tabs.push(newTab)
+      }
+
       if (this.account.isMiner) {
         const newTab = {
           id: 3,


### PR DESCRIPTION
This branch adds a new field "hasInternalTransfers" to the graphQL Account return type. This is then used to conditionally show or hide the internal transfers tab on PageDetailsAddress.vue