### PR TITLE
Fix/slow query block summaries by author

### DIFF
--- a/apps/api/src/dao/block.service.ts
+++ b/apps/api/src/dao/block.service.ts
@@ -94,7 +94,7 @@ export class BlockService {
         async (txn): Promise<[BlockSummary[], number]> => {
 
           const count = await txn.count(BlockHeaderEntity, {
-            where: { author }
+            where: { author },
           })
 
           if (count === 0) return [[], count]


### PR DESCRIPTION
This PR improves the performance of blockSummariesByAuthor query by replacing a findAndCount() with separate find() and count() methods within a transaction. As a result, the count SQL query does not perform a join and the performance is improved. 