### PR TITLE
fix: Default historical charts to week view

### DIFF
--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -318,17 +318,18 @@ export interface Metadata {
 
 export interface IQuery {
     accountByAddress(address: string): Account | Promise<Account>;
+    blockMetricsTransaction(offset?: number, limit?: number): BlockMetricsTransactionPage | Promise<BlockMetricsTransactionPage>;
+    blockMetricsTransactionFee(offset?: number, limit?: number): BlockMetricsTransactionFeePage | Promise<BlockMetricsTransactionFeePage>;
+    blockMetricsTimeseries(start: Date, end: Date, bucket: TimeBucket, fields: BlockMetricField[]): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
     hashRate(): BigNumber | Promise<BigNumber>;
     blockSummaries(fromBlock?: BigNumber, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;
     blockSummariesByAuthor(author: string, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;
     blockByHash(hash: string): Block | Promise<Block>;
     blockByNumber(number: BigNumber): Block | Promise<Block>;
-    blockMetricsTransaction(offset?: number, limit?: number): BlockMetricsTransactionPage | Promise<BlockMetricsTransactionPage>;
-    blockMetricsTransactionFee(offset?: number, limit?: number): BlockMetricsTransactionFeePage | Promise<BlockMetricsTransactionFeePage>;
-    blockMetricsTimeseries(start: Date, end: Date, bucket: TimeBucket, fields: BlockMetricField[]): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
     contractByAddress(address: string): Contract | Promise<Contract>;
     contractsCreatedBy(creator: string, offset?: number, limit?: number): ContractSummaryPage | Promise<ContractSummaryPage>;
     metadata(): Metadata | Promise<Metadata>;
+    search(query: string): Search | Promise<Search>;
     tokenHolder(address: string, holderAddress: string): TokenHolder | Promise<TokenHolder>;
     addressAllTokensOwned(address: string, offset?: number, limit?: number): TokenPage | Promise<TokenPage>;
     addressTotalTokenValueUSD(address: string): BigNumber | Promise<BigNumber>;
@@ -339,7 +340,6 @@ export interface IQuery {
     tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
     tokensMetadata(symbols?: string[]): TokenMetadata[] | Promise<TokenMetadata[]>;
     tokenHolders(address: string, offset?: number, limit?: number): TokenHoldersPage | Promise<TokenHoldersPage>;
-    search(query: string): Search | Promise<Search>;
     tokenTransfersByContractAddressesForHolder(contractAddresses: string[], holderAddress: string, filter?: FilterEnum, limit?: number, page?: number, timestampFrom?: number, timestampTo?: number): TransferPage | Promise<TransferPage>;
     internalTransactionsByAddress(address: string, offset?: number, limit?: number): TransferPage | Promise<TransferPage>;
     tokenBalancesByContractAddressForHolder(contractAddress: string, holderAddress: string, timestampFrom?: number, timestampTo?: number): BalancesPage | Promise<BalancesPage>;
@@ -388,11 +388,11 @@ export interface Search {
 }
 
 export interface ISubscription {
-    newBlock(): BlockSummary | Promise<BlockSummary>;
-    hashRate(): BigNumber | Promise<BigNumber>;
     newBlockMetric(): BlockMetric | Promise<BlockMetric>;
     newBlockMetricsTransaction(): BlockMetricsTransaction | Promise<BlockMetricsTransaction>;
     newBlockMetricsTransactionFee(): BlockMetricsTransactionFee | Promise<BlockMetricsTransactionFee>;
+    newBlock(): BlockSummary | Promise<BlockSummary>;
+    hashRate(): BigNumber | Promise<BigNumber>;
     isSyncing(): boolean | Promise<boolean>;
     newTransaction(): TransactionSummary | Promise<TransactionSummary>;
 }

--- a/apps/explorer/src/modules/charts/components/Chart.vue
+++ b/apps/explorer/src/modules/charts/components/Chart.vue
@@ -7,9 +7,9 @@
       </v-flex>
       <v-flex xs12 sm3 v-if="!liveChart">
         <v-layout align-center justify-end pa-3>
-          <button flat :class="classAll" @click="toggleData = 0" small>{{ $tc('charts.states.all', 2) }}</button>
-          <button flat :class="classWeek" @click="toggleData = 1" small>{{ $tc('charts.states.week', 2) }}</button>
-          <button flat :class="classMonth" @click="toggleData = 2" small>{{ $tc('charts.states.month', 2) }}</button>
+          <button flat :class="classWeek" @click="toggleData = 0" small>{{ $tc('charts.states.week', 2) }}</button>
+          <button flat :class="classMonth" @click="toggleData = 1" small>{{ $tc('charts.states.month', 2) }}</button>
+          <button flat :class="classAll" @click="toggleData = 2" small>{{ $tc('charts.states.all', 2) }}</button>
           <!-- <button flat :class="classMonth" small>1Y</button> -->
         </v-layout>
       </v-flex>
@@ -134,15 +134,15 @@ export default class AppChart extends Vue {
     Computed
   ===================================================================================
   */
-  get classAll(): string {
+  get classWeek(): string {
     return this.toggleData === 0 ? 'active-button' : 'button'
   }
 
-  get classWeek(): string {
+  get classMonth(): string {
     return this.toggleData === 1 ? 'active-button' : 'button'
   }
 
-  get classMonth(): string {
+  get classAll(): string {
     return this.toggleData === 2 ? 'active-button' : 'button'
   }
 

--- a/apps/explorer/src/modules/charts/components/history/ChartTimeseries.vue
+++ b/apps/explorer/src/modules/charts/components/history/ChartTimeseries.vue
@@ -183,13 +183,13 @@ export default class ChartTimeseries extends Vue {
 
     switch (value) {
       case 0:
-        period = 'all'
-        break
-      case 1:
         period = 'week'
         break
-      case 2:
+      case 1:
         period = 'month'
+        break
+      case 2:
+        period = 'all'
         break
       case 3:
         period = 'year'


### PR DESCRIPTION
This PR defaults the historical charts to the "week" option in order to prevent the default ("all") being a very slow query. It also changes the order of the period toggle buttons to week > month > all, which is the more logical ordering.