### PR TITLE
Feature/improve block metrics queries performance

### DIFF
--- a/apps/api/src/dao/block-metrics.service.ts
+++ b/apps/api/src/dao/block-metrics.service.ts
@@ -161,7 +161,7 @@ export class BlockMetricsService {
         throw new Error(`Unexpected bucket value: ${bucket}`)
     }
 
-      switch (field) {
+    switch (field) {
         case BlockMetricField.AVG_BLOCK_TIME:
           select.push('round(avg(block_time)) as avg_block_time')
           break

--- a/apps/api/src/graphql/block-metrics/block-metrics.graphql
+++ b/apps/api/src/graphql/block-metrics/block-metrics.graphql
@@ -17,7 +17,7 @@ type Query {
   blockMetricsTransaction(offset: Int = 0, limit: Int = 20): BlockMetricsTransactionPage!
   blockMetricsTransactionFee(offset: Int = 0, limit: Int = 20): BlockMetricsTransactionFeePage!
 
-  blockMetricsTimeseries(start: Date!, end: Date!, bucket: TimeBucket!, fields: [BlockMetricField!]!): [AggregateBlockMetric!]!
+  blockMetricsTimeseries(start: Date!, end: Date!, bucket: TimeBucket!, field: BlockMetricField!): [AggregateBlockMetric!]!
 
 }
 

--- a/apps/api/src/graphql/block-metrics/block-metrics.resolvers.ts
+++ b/apps/api/src/graphql/block-metrics/block-metrics.resolvers.ts
@@ -50,9 +50,9 @@ export class BlockMetricsResolvers {
     @Args('start') start: Date,
     @Args('end') end: Date,
     @Args('bucket') bucket: TimeBucket,
-    @Args({ name: 'fields', type: () => [BlockMetricField] }) fields: BlockMetricField[],
+    @Args('field') field: BlockMetricField,
   ): Promise<AggregateBlockMetricDto[]> {
-    const entities = await this.blockMetricsService.timeseries(start, end, bucket, fields)
+    const entities = await this.blockMetricsService.timeseries(start, end, bucket, field)
     return entities.map(e => new AggregateBlockMetricDto(e))
   }
 

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -321,7 +321,7 @@ export interface IQuery {
     accountByAddress(address: string): Account | Promise<Account>;
     blockMetricsTransaction(offset?: number, limit?: number): BlockMetricsTransactionPage | Promise<BlockMetricsTransactionPage>;
     blockMetricsTransactionFee(offset?: number, limit?: number): BlockMetricsTransactionFeePage | Promise<BlockMetricsTransactionFeePage>;
-    blockMetricsTimeseries(start: Date, end: Date, bucket: TimeBucket, fields: BlockMetricField[]): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
+    blockMetricsTimeseries(start: Date, end: Date, bucket: TimeBucket, field: BlockMetricField): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
     hashRate(): BigNumber | Promise<BigNumber>;
     blockSummaries(fromBlock?: BigNumber, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;
     blockSummariesByAuthor(author: string, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;

--- a/apps/api/src/orm/entities/block-metrics-header.entity.ts
+++ b/apps/api/src/orm/entities/block-metrics-header.entity.ts
@@ -1,0 +1,34 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm'
+import { assignClean } from '@app/shared/utils'
+import { BigNumberTransformer } from '@app/orm/transformers/big-number.transformer'
+import { BigNumber } from 'bignumber.js'
+
+@Entity('canonical_block_metrics_header')
+export class BlockMetricsHeaderEntity {
+
+  constructor(data: any) {
+    assignClean(this, data)
+  }
+
+  @PrimaryColumn({ type: 'numeric', readonly: true, transformer: new BigNumberTransformer() })
+  number!: BigNumber
+
+  @Column({ type: 'character', length: 66, unique: true, readonly: true })
+  blockHash!: string
+
+  @Column({ type: 'timestamp', readonly: true })
+  timestamp!: Date
+
+  @Column({type: 'int', readonly: true})
+  blockTime!: number
+
+  @Column({type: 'int', readonly: true})
+  numUncles!: number
+
+  @Column({type: 'numeric', readonly: true, transformer: new BigNumberTransformer()})
+  difficulty!: BigNumber
+
+  @Column({type: 'numeric', readonly: true, transformer: new BigNumberTransformer()})
+  totalDifficulty!: BigNumber
+
+}

--- a/apps/api/src/orm/entities/block-metrics-transaction-trace.entity.ts
+++ b/apps/api/src/orm/entities/block-metrics-transaction-trace.entity.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm'
+
+@Entity('canonical_block_metrics_transaction_trace')
+export class BlockMetricsTransactionTraceEntity {
+
+  @PrimaryColumn({ type: 'character', length: 66, unique: true, readonly: true })
+  blockHash!: string
+
+  @PrimaryColumn({ type: 'timestamp', readonly: true })
+  timestamp!: Date
+
+  @Column({type: 'int', readonly: true})
+  totalTxs!: number
+
+  @Column({type: 'int', readonly: true})
+  numSuccessfulTxs!: number
+
+  @Column({type: 'int', readonly: true})
+  numFailedTxs!: number
+
+  @Column({type: 'int', readonly: true})
+  numInternalTxs!: number
+}

--- a/apps/explorer/apollo/schemas/api.json
+++ b/apps/explorer/apollo/schemas/api.json
@@ -161,23 +161,15 @@
                 "defaultValue": null
               },
               {
-                "name": "fields",
+                "name": "field",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "ENUM",
-                        "name": "BlockMetricField",
-                        "ofType": null
-                      }
-                    }
+                    "kind": "ENUM",
+                    "name": "BlockMetricField",
+                    "ofType": null
                   }
                 },
                 "defaultValue": null

--- a/apps/explorer/src/modules/charts/components/history/timeseries.graphql
+++ b/apps/explorer/src/modules/charts/components/history/timeseries.graphql
@@ -1,42 +1,42 @@
 
 query avgGasPriceHistory($start: Date!, $end: Date!, $bucket: TimeBucket!) {
-  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, fields: [AVG_GAS_PRICE]) {
+  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, field: AVG_GAS_PRICE) {
     ...AvgGasPriceMetric
   }
 }
 
 query avgBlockTimeHistory($start: Date!, $end: Date!, $bucket: TimeBucket!) {
-  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, fields: [AVG_BLOCK_TIME]) {
+  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, field: AVG_BLOCK_TIME) {
     ...AvgBlockTimeMetric
   }
 }
 
 query avgGasLimitHistory($start: Date!, $end: Date!, $bucket: TimeBucket!) {
-  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, fields: [AVG_GAS_LIMIT]) {
+  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, field: AVG_GAS_LIMIT) {
     ...AvgGasLimitMetric
   }
 }
 
 query avgDifficultyHistory($start: Date!, $end: Date!, $bucket: TimeBucket!) {
-  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, fields: [AVG_DIFFICULTY]) {
+  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, field: AVG_DIFFICULTY) {
     ...AvgDifficultyMetric
   }
 }
 
 query avgNumFailedTxsHistory($start: Date!, $end: Date!, $bucket: TimeBucket!) {
-  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, fields: [AVG_NUM_FAILED_TXS]) {
+  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, field: AVG_NUM_FAILED_TXS) {
     ...AvgNumFailedTxsMetric
   }
 }
 
 query avgNumSuccessfulTxsHistory($start: Date!, $end: Date!, $bucket: TimeBucket!) {
-  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, fields: [AVG_NUM_SUCCESSFUL_TXS]) {
+  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, field: AVG_NUM_SUCCESSFUL_TXS) {
     ...AvgNumSuccessfulTxsMetric
   }
 }
 
 query avgTxFeesHistory($start: Date!, $end: Date!, $bucket: TimeBucket!) {
-  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, fields: [AVG_TX_FEES]) {
+  blockMetricsTimeseries(start: $start, end: $end, bucket: $bucket, field: AVG_TX_FEES) {
     ...AvgTxFeesMetric
   }
 }


### PR DESCRIPTION
This PR improves the performance of BlockMetricsService "timeseries" query by avoiding querying canonical_block_metrics view. 