### PR TITLE
fix/ Table blocks placeholder row alignment

### DIFF
--- a/apps/explorer/src/modules/blocks/components/TableBlocks.vue
+++ b/apps/explorer/src/modules/blocks/components/TableBlocks.vue
@@ -7,7 +7,17 @@
       TITLE
     =====================================================================================
     -->
-    <v-layout v-if="pageType != 'home'" align-end justify-space-between row wrap fill-height pb-1 pr-2 pl-2>
+    <v-layout
+      v-if="pageType != 'home'"
+      align-end
+      justify-space-between
+      row
+      wrap
+      fill-height
+      pb-1
+      pr-2
+      pl-2
+    >
       <v-flex xs12 sm5 md4 class="title-live" pb-0>
         <v-layout align-end justify-start row fill-height>
           <v-card-title class="title font-weight-bold pl-2">{{ getTitle }}</v-card-title>
@@ -34,7 +44,12 @@
       <v-spacer />
       <v-flex xs4 md1>
         <v-layout justify-end>
-          <v-btn outline color="secondary" class="text-capitalize" to="/blocks">{{ $t('btn.view-all') }}</v-btn>
+          <v-btn
+            outline
+            color="secondary"
+            class="text-capitalize"
+            to="/blocks"
+          >{{ $t('btn.view-all') }}</v-btn>
         </v-layout>
       </v-flex>
     </v-layout>
@@ -52,7 +67,13 @@
     -->
     <v-layout pl-2 pr-2>
       <v-flex hidden-xs-only sm12>
-        <v-card v-if="!hasError" color="info" flat class="white--text pl-3 pr-1 table-blocks-header-card" height="40px">
+        <v-card
+          v-if="!hasError"
+          color="info"
+          flat
+          class="white--text pl-3 pr-1 table-blocks-header-card"
+          height="40px"
+        >
           <v-layout align-center justify-start row fill-height pr-3>
             <v-flex sm2>
               <h5>{{ $t('block.number') }}</h5>
@@ -83,21 +104,36 @@
 
         <div xs12 v-if="loading">
           <div v-for="i in maxItems" :key="i">
-            <v-layout grid-list-xs row wrap align-center justify-start fill-height class="pl-2 pr-2 pt-2">
-              <v-flex xs6 sm2 order-xs1 class="order-gt-xs-0">
-                <v-flex xs12 class="table-row-loading"></v-flex>
-              </v-flex>
-              <v-flex xs12 sm7 md6>
-                <v-flex xs12 class="table-row-loading"></v-flex>
-              </v-flex>
-              <v-flex hidden-sm-and-down md2 order-xs4 order-sm3>
-                <v-flex xs12 class="table-row-loading"></v-flex>
-              </v-flex>
-              <v-flex d-flex xs6 sm3 md2 order-xs2 order-md4>
-                <v-flex xs12 class="table-row-loading"></v-flex>
-              </v-flex>
-            </v-layout>
-            <v-divider class="mb-2 mt-2" />
+            <div :class="[$vuetify.breakpoint.name === 'xs'? 'table-row-mobile ma-2' : '']">
+              <v-layout
+                grid-list-xs
+                row
+                wrap
+                align-center
+                justify-start
+                fill-height
+                class="pl-4 pr-4 pt-2"
+              >
+                <v-flex xs4 sm2>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
+                </v-flex>
+                <v-spacer class="hidden-sm-and-up" />
+                <v-flex xs3 class="hidden-sm-and-up">
+                  <v-flex xs12 class="table-row-loading"></v-flex>
+                </v-flex>
+                <v-flex xs12 sm7 xl6>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
+                </v-flex>
+                <v-flex xs12 sm2>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
+                </v-flex>
+                <v-flex xs4 sm1 xl2>
+                  <v-flex xs12 class="table-row-loading"></v-flex>
+                </v-flex>
+              </v-layout>
+              <v-divider class="mb-2 mt-2 hidden-xs-only" />
+            </div>
+            <div></div>
           </div>
         </div>
       </v-layout>
@@ -329,7 +365,8 @@ export default class TableBlocks extends Vue {
         */
 
   get loading(): boolean | undefined {
-    return this.$apollo.queries.blockPage.loading || this.syncing
+    // return this.$apollo.queries.blockPage.loading || this.syncing
+    return true
   }
 
   /**
@@ -365,12 +402,10 @@ export default class TableBlocks extends Vue {
 .title-live {
   min-height: 60px;
 }
-  .table-blocks-header-card {
-    margin-right: 1px
-  }
-@media all and (min-width: 600px) {
-  .order-gt-xs-0 {
-    order: 0;
-  }
+.table-blocks-header-card {
+  margin-right: 1px;
+}
+.table-row-mobile {
+  border: 1px solid #b4bfd2;
 }
 </style>

--- a/apps/explorer/src/modules/blocks/components/TableBlocks.vue
+++ b/apps/explorer/src/modules/blocks/components/TableBlocks.vue
@@ -84,7 +84,7 @@
         <div xs12 v-if="loading">
           <div v-for="i in maxItems" :key="i">
             <v-layout grid-list-xs row wrap align-center justify-start fill-height class="pl-2 pr-2 pt-2">
-              <v-flex xs6 sm2 order-xs1>
+              <v-flex xs6 sm2 order-xs1 class="order-gt-xs-0">
                 <v-flex xs12 class="table-row-loading"></v-flex>
               </v-flex>
               <v-flex xs12 sm7 md6>
@@ -368,4 +368,9 @@ export default class TableBlocks extends Vue {
   .table-blocks-header-card {
     margin-right: 1px
   }
+@media all and (min-width: 600px) {
+  .order-gt-xs-0 {
+    order: 0;
+  }
+}
 </style>

--- a/apps/explorer/src/modules/blocks/components/TableBlocks.vue
+++ b/apps/explorer/src/modules/blocks/components/TableBlocks.vue
@@ -7,17 +7,7 @@
       TITLE
     =====================================================================================
     -->
-    <v-layout
-      v-if="pageType != 'home'"
-      align-end
-      justify-space-between
-      row
-      wrap
-      fill-height
-      pb-1
-      pr-2
-      pl-2
-    >
+    <v-layout v-if="pageType != 'home'" align-end justify-space-between row wrap fill-height pb-1 pr-2 pl-2>
       <v-flex xs12 sm5 md4 class="title-live" pb-0>
         <v-layout align-end justify-start row fill-height>
           <v-card-title class="title font-weight-bold pl-2">{{ getTitle }}</v-card-title>
@@ -44,12 +34,7 @@
       <v-spacer />
       <v-flex xs4 md1>
         <v-layout justify-end>
-          <v-btn
-            outline
-            color="secondary"
-            class="text-capitalize"
-            to="/blocks"
-          >{{ $t('btn.view-all') }}</v-btn>
+          <v-btn outline color="secondary" class="text-capitalize" to="/blocks">{{ $t('btn.view-all') }}</v-btn>
         </v-layout>
       </v-flex>
     </v-layout>
@@ -67,13 +52,7 @@
     -->
     <v-layout pl-2 pr-2>
       <v-flex hidden-xs-only sm12>
-        <v-card
-          v-if="!hasError"
-          color="info"
-          flat
-          class="white--text pl-3 pr-1 table-blocks-header-card"
-          height="40px"
-        >
+        <v-card v-if="!hasError" color="info" flat class="white--text pl-3 pr-1 table-blocks-header-card" height="40px">
           <v-layout align-center justify-start row fill-height pr-3>
             <v-flex sm2>
               <h5>{{ $t('block.number') }}</h5>
@@ -104,16 +83,8 @@
 
         <div xs12 v-if="loading">
           <div v-for="i in maxItems" :key="i">
-            <div :class="[$vuetify.breakpoint.name === 'xs'? 'table-row-mobile ma-2' : '']">
-              <v-layout
-                grid-list-xs
-                row
-                wrap
-                align-center
-                justify-start
-                fill-height
-                class="pl-4 pr-4 pt-2"
-              >
+            <div :class="[$vuetify.breakpoint.name === 'xs' ? 'table-row-mobile ma-2' : '']">
+              <v-layout grid-list-xs row wrap align-center justify-start fill-height class="pl-4 pr-4 pt-2">
                 <v-flex xs4 sm2>
                   <v-flex xs12 class="table-row-loading"></v-flex>
                 </v-flex>

--- a/apps/explorer/src/modules/blocks/components/TableBlocks.vue
+++ b/apps/explorer/src/modules/blocks/components/TableBlocks.vue
@@ -336,8 +336,7 @@ export default class TableBlocks extends Vue {
         */
 
   get loading(): boolean | undefined {
-    // return this.$apollo.queries.blockPage.loading || this.syncing
-    return true
+    return this.$apollo.queries.blockPage.loading || this.syncing
   }
 
   /**


### PR DESCRIPTION
The directive xs-1 (used to add css "order: 1" on xs screen) was affecting the first column on all screen sizes causing the bad alignment. I couldn't find a vuetify class that would only add this on xs screens (as opposed to xs and up) or a class which would move the column back to index 0 on sm screens and larger, so I added a new one. @olgakup, if you know of a vuetify class/directive that would do this please let me know and I will update this PR as that would be much cleaner!