### PR TITLE
fix: Handle invalid JSON when constructing TokenMetadataDto

### DIFF
--- a/apps/api/src/orm/orm.module.ts
+++ b/apps/api/src/orm/orm.module.ts
@@ -14,7 +14,7 @@ import { DbConnection, SnakeCaseNamingStrategy } from '@app/orm/config'
         synchronize: false,
         namingStrategy: new SnakeCaseNamingStrategy(),
         entities: ['src/**/**.entity{.ts,.js}'],
-        logging: ['error', 'query'],
+        logging: ['error'],
         maxQueryExecutionTime: 1000,
         cache: {
           type: 'redis',
@@ -33,7 +33,7 @@ import { DbConnection, SnakeCaseNamingStrategy } from '@app/orm/config'
         synchronize: false,
         namingStrategy: new SnakeCaseNamingStrategy(),
         entities: ['src/**/**.entity{.ts,.js}'],
-        logging: ['error', 'query'],
+        logging: ['error'],
         maxQueryExecutionTime: 1000,
         cache: {
           type: 'redis',


### PR DESCRIPTION
Catch error parsing invalid JSON field for eth_list_contract_metadata "support" or "logo" fields when building TokenMetadataDto objects.