### PR TITLE
Feature/query token exchange rates and metadata by address

### DIFF
--- a/apps/api/src/dao/dao.module.ts
+++ b/apps/api/src/dao/dao.module.ts
@@ -30,6 +30,7 @@ import {TxService} from '@app/dao/tx.service'
 import {BlockMetricEntity} from '@app/orm/entities/block-metric.entity'
 import { MetadataEntity } from '@app/orm/entities/metadata.entity'
 import { MetadataService } from '@app/dao/metadata.service'
+import { TokenMetadataEntity } from '@app/orm/entities/token-metadata.entity'
 import { DbConnection } from '@app/orm/config'
 import { InternalTransferEntity } from '@app/orm/entities/internal-transfer.entity'
 import { TokenDetailEntity } from '@app/orm/entities/token-detail.entity'
@@ -56,6 +57,7 @@ import { TokenDetailEntity } from '@app/orm/entities/token-detail.entity'
       BlockMetricEntity,
       MetadataEntity,
       InternalTransferEntity,
+      TokenMetadataEntity,
       TokenDetailEntity,
     ], DbConnection.Principal),
     TypeOrmModule.forFeature([

--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -102,24 +102,6 @@ export class TokenService {
     return new TokenDto(tokenData)
   }
 
-  private extractFromJson(field: string, json?: string | null): string | undefined {
-
-    if (!json) {
-      return undefined
-    }
-
-    let extracted
-
-    try {
-      extracted = JSON.parse(json)[field]
-    } catch (e) {
-      return 'Invalid JSON'
-    }
-
-    return extracted
-
-  }
-
   async findCoinExchangeRate(pair: string): Promise<CoinExchangeRateEntity | undefined> {
     const findOptions: FindOneOptions = {
       where: { id: pair },

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -335,11 +335,11 @@ export interface IQuery {
     addressAllTokensOwned(address: string, offset?: number, limit?: number): TokenPage | Promise<TokenPage>;
     addressTotalTokenValueUSD(address: string): BigNumber | Promise<BigNumber>;
     coinExchangeRate(pair: ExchangeRatePair): CoinExchangeRate | Promise<CoinExchangeRate>;
-    tokenExchangeRates(symbols: string[], sort?: TokenExchangeRateFilter, offset?: number, limit?: number): TokenExchangeRatesPage | Promise<TokenExchangeRatesPage>;
+    tokenExchangeRates(symbols?: string[], names?: string[], addresses?: string[], sort?: TokenExchangeRateFilter, offset?: number, limit?: number): TokenExchangeRatesPage | Promise<TokenExchangeRatesPage>;
     totalNumTokenExchangeRates(): number | Promise<number>;
     tokenExchangeRateBySymbol(symbol: string): TokenExchangeRate | Promise<TokenExchangeRate>;
     tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
-    tokensMetadata(symbols?: string[]): TokenMetadata[] | Promise<TokenMetadata[]>;
+    tokensMetadata(symbols?: string[], names?: string[], addresses?: string[], offset?: number, limit?: number): TokenMetadataPage | Promise<TokenMetadataPage>;
     tokenHolders(address: string, offset?: number, limit?: number): TokenHoldersPage | Promise<TokenHoldersPage>;
     tokenDetailByAddress(address: string): TokenDetail | Promise<TokenDetail>;
     tokenTransfersByContractAddressesForHolder(contractAddresses: string[], holderAddress: string, filter?: FilterEnum, limit?: number, page?: number, timestampFrom?: number, timestampTo?: number): TransferPage | Promise<TransferPage>;
@@ -478,6 +478,11 @@ export interface TokenMetadata {
     address?: string;
     decimals?: number;
     logo?: string;
+}
+
+export interface TokenMetadataPage {
+    items: TokenMetadata[];
+    totalCount: number;
 }
 
 export interface TokenPage {

--- a/apps/api/src/graphql/tokens/dto/token-metadata-page.dto.ts
+++ b/apps/api/src/graphql/tokens/dto/token-metadata-page.dto.ts
@@ -1,0 +1,16 @@
+import { TokenMetadata, TokenMetadataPage } from '@app/graphql/schema'
+import { assignClean } from '@app/shared/utils'
+import { TokenMetadataDto } from '@app/graphql/tokens/dto/token-metadata.dto'
+
+export class TokenMetadataPageDto implements TokenMetadataPage {
+  items!: TokenMetadata[]
+  totalCount!: number
+
+  constructor(data) {
+    if (data.items) {
+      this.items = data.items.map(i => new TokenMetadataDto(i))
+      delete data.items
+    }
+    assignClean(this, data)
+  }
+}

--- a/apps/api/src/graphql/tokens/dto/token-metadata.dto.ts
+++ b/apps/api/src/graphql/tokens/dto/token-metadata.dto.ts
@@ -1,5 +1,6 @@
 import { TokenMetadata } from '@app/graphql/schema'
 import { assignClean } from '@app/shared/utils'
+import { TokenMetadataEntity } from '@app/orm/entities/token-metadata.entity'
 
 export class TokenMetadataDto implements TokenMetadata {
 
@@ -11,8 +12,10 @@ export class TokenMetadataDto implements TokenMetadata {
   decimals?: number
   logo?: string
 
-  constructor(data: any) {
+  constructor(data: TokenMetadataEntity) {
     assignClean(this, data)
+    this.email = data.support ? JSON.parse(data.support).email : null
+    this.logo = data.logo ? JSON.parse(data.logo).src : null
   }
 
 }

--- a/apps/api/src/graphql/tokens/dto/token-metadata.dto.ts
+++ b/apps/api/src/graphql/tokens/dto/token-metadata.dto.ts
@@ -1,5 +1,5 @@
 import { TokenMetadata } from '@app/graphql/schema'
-import { assignClean } from '@app/shared/utils'
+import { assignClean, extractFromJson } from '@app/shared/utils'
 import { TokenMetadataEntity } from '@app/orm/entities/token-metadata.entity'
 
 export class TokenMetadataDto implements TokenMetadata {
@@ -14,8 +14,8 @@ export class TokenMetadataDto implements TokenMetadata {
 
   constructor(data: TokenMetadataEntity) {
     assignClean(this, data)
-    this.email = data.support ? JSON.parse(data.support).email : null
-    this.logo = data.logo ? JSON.parse(data.logo).src : null
+    this.email = extractFromJson('email', data.support)
+    this.logo = extractFromJson('src', data.logo)
   }
 
 }

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -3,11 +3,11 @@ type Query {
   addressAllTokensOwned(address: String!, offset: Int = 0, limit: Int = 10): TokenPage!
   addressTotalTokenValueUSD(address: String!): BigNumber
   coinExchangeRate(pair: ExchangeRatePair!): CoinExchangeRate
-  tokenExchangeRates(symbols: [String!], sort: TokenExchangeRateFilter, offset: Int = 0, limit: Int = 20): TokenExchangeRatesPage!
+  tokenExchangeRates(symbols: [String], names: [String], addresses: [String], sort: TokenExchangeRateFilter, offset: Int = 0, limit: Int = 20): TokenExchangeRatesPage!
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
   tokenExchangeRateByAddress(address: String!): TokenExchangeRate
-  tokensMetadata(symbols: [String]): [TokenMetadata!]!
+  tokensMetadata(symbols: [String], names: [String], addresses: [String], offset: Int = 0, limit: Int = 20): TokenMetadataPage!
   tokenHolders(address: String!, offset: Int = 0, limit: Int = 20): TokenHoldersPage!
   tokenDetailByAddress(address: String!): TokenDetail
 }
@@ -84,6 +84,11 @@ type TokenMetadata {
   address: String
   decimals: Int
   logo: String
+}
+
+type TokenMetadataPage {
+  items: [TokenMetadata!]!
+  totalCount: Int!
 }
 
 type TokenDetail {

--- a/apps/api/src/graphql/tokens/token.resolvers.spec.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.spec.ts
@@ -17,6 +17,7 @@ import { TokenExchangeRatePageDto } from './dto/token-exchange-rate-page.dto'
 import { TokenExchangeRateDto } from './dto/token-exchange-rate.dto'
 import { TokenMetadataDto } from './dto/token-metadata.dto'
 import { MetadataService } from '../../dao/metadata.service'
+import { TokenMetadataEntity } from '../../orm/entities/token-metadata.entity'
 
 const contractAddressOne = '0000000000000000000000000000000000000001'
 const contractAddressTwo = '0000000000000000000000000000000000000002'
@@ -49,7 +50,7 @@ const tokenMetadataThree = {
   currentPrice: 3
 }
 
-const erc20Metadata = [
+const tokenMetadata = [
   tokenMetadataOne,
   tokenMetadataTwo,
   tokenMetadataThree
@@ -121,7 +122,8 @@ const tokenExchangeRates = [
     totalVolume: 1000,
     marketCap: 10,
     marketCapRank: 1,
-    symbol: 'T1'
+    symbol: 'T1',
+    name: 'Token 1'
   },
   {
     address: contractAddressTwo,
@@ -129,7 +131,8 @@ const tokenExchangeRates = [
     totalVolume: 2000,
     marketCap: 9,
     marketCapRank: 2,
-    symbol: 'T2'
+    symbol: 'T2',
+    name: 'Token 2'
   },
   {
     address: contractAddressThree,
@@ -137,7 +140,8 @@ const tokenExchangeRates = [
     totalVolume: 3000,
     marketCap: 8,
     marketCapRank: 3,
-    symbol: 'T3'
+    symbol: 'T3',
+    name: 'Token 3'
   },
   {
     address: contractAddressFour,
@@ -145,7 +149,8 @@ const tokenExchangeRates = [
     totalVolume: 4000,
     marketCap: 7,
     marketCapRank: 4,
-    symbol: 'T4'
+    symbol: 'T4',
+    name: 'Token 4'
   }
 ]
 
@@ -195,10 +200,19 @@ const tokenServiceMock = {
     const item = coinExchangeRates.find(c => c.id === pair)
     return item ? new CoinExchangeRateEntity(item) : undefined
   },
-  async findTokenExchangeRates(sort: string, limit: number = 10, offset: number = 0, symbols: string[] = []): Promise<[TokenExchangeRateEntity[], number]> {
+  async findTokenExchangeRates(
+    sort: string = 'market_cap_rank',
+    limit: number = 10,
+    offset: number = 0,
+    symbols: string[] = [],
+    names: string[] = [],
+    addresses: string[] = [],
+  ): Promise<[TokenExchangeRateEntity[], number]> {
 
     // Filter by symbol if set
-    let items = symbols && symbols.length ? tokenExchangeRates.filter(t => symbols.includes(t.symbol)) : tokenExchangeRates
+    let items = symbols.length || names.length || addresses.length ?
+      tokenExchangeRates.filter(t => symbols.includes(t.symbol) || names.includes(t.name) || addresses.includes(t.address)) :
+      tokenExchangeRates
 
     // Total count
     const totalCount = items.length
@@ -249,9 +263,22 @@ const tokenServiceMock = {
   async countTokenHolders(address: string): Promise<number> {
     return erc20Balances.filter(e => e.contract === address).length
   },
-  async findTokensMetadata(symbols: string[] = []): Promise<TokenMetadataDto[]> {
-    const items = erc20Metadata.filter(e => symbols.includes(e.symbol))
-    return items.map(i => new TokenMetadataDto(i))
+  async findTokensMetadata(
+    symbols: string[] = [],
+    names: string[] = [],
+    addresses: string[] = [],
+    offset: number = 0,
+    limit: number = 20,
+  ): Promise<[TokenMetadataEntity[], number]> {
+    let items = symbols.length || names.length || addresses.length ?
+      tokenMetadata.filter(t => symbols.includes(t.symbol) || names.includes(t.name) || addresses.includes(t.address)) :
+      tokenMetadata
+
+    const totalCount = items.length
+
+    items = items.slice(offset, offset + limit)
+
+    return [items.map(i => new TokenMetadataEntity(i)), totalCount]
   }
 }
 
@@ -502,7 +529,7 @@ describe('TokenResolvers', () => {
   describe('tokenExchangeRates', () => {
     it('should return an instance of TokenExchangeRatePageDto with items and totalCount', async () => {
 
-      const tokenExchangeRatesPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 10, 0)
+      const tokenExchangeRatesPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 10, 0)
 
       expect(tokenExchangeRatesPage).not.toBeNull()
       expect(tokenExchangeRatesPage).toBeInstanceOf(TokenExchangeRatePageDto)
@@ -515,7 +542,7 @@ describe('TokenResolvers', () => {
 
     it('should respect given offset and limit parameters', async () => {
 
-      const pageOne = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 2, 0)
+      const pageOne = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 2, 0)
 
       expect(pageOne).not.toBeNull()
       expect(pageOne).toBeInstanceOf(TokenExchangeRatePageDto)
@@ -528,7 +555,7 @@ describe('TokenResolvers', () => {
       expect(pageOne.items[1]).toHaveProperty('address', contractAddressThree)
       expect(pageOne.items[1]).toHaveProperty('currentPrice', 3)
 
-      const pageTwo = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 2, 2)
+      const pageTwo = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 2, 2)
 
       expect(pageTwo).not.toBeNull()
       expect(pageTwo).toBeInstanceOf(TokenExchangeRatePageDto)
@@ -546,7 +573,7 @@ describe('TokenResolvers', () => {
 
       // Check an empty array is returned if offset >= totalCount
 
-      const pageThree = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 2, 4)
+      const pageThree = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 2, 4)
 
       expect(pageThree).not.toBeNull()
       expect(pageThree).toBeInstanceOf(TokenExchangeRatePageDto)
@@ -557,7 +584,7 @@ describe('TokenResolvers', () => {
 
     it('should filter by provided symbols array', async () => {
 
-      const pageOne = await tokenResolvers.tokenExchangeRates(['T1', 'T2'], TokenExchangeRateFilter.price_high, 10, 0)
+      const pageOne = await tokenResolvers.tokenExchangeRates(['T1', 'T2'], [], [], TokenExchangeRateFilter.price_high, 10, 0)
       expect(pageOne).not.toBeNull()
       expect(pageOne).toBeInstanceOf(TokenExchangeRatePageDto)
       expect(pageOne).toHaveProperty('items')
@@ -566,7 +593,7 @@ describe('TokenResolvers', () => {
       expect(pageOne.items[0]).toHaveProperty('symbol', 'T2')
       expect(pageOne.items[1]).toHaveProperty('symbol', 'T1')
 
-      const pageTwo = await tokenResolvers.tokenExchangeRates(['T3'], TokenExchangeRateFilter.price_high, 10, 0)
+      const pageTwo = await tokenResolvers.tokenExchangeRates(['T3'], [], [], TokenExchangeRateFilter.price_high, 10, 0)
       expect(pageTwo).not.toBeNull()
       expect(pageTwo).toBeInstanceOf(TokenExchangeRatePageDto)
       expect(pageTwo).toHaveProperty('items')
@@ -578,7 +605,71 @@ describe('TokenResolvers', () => {
 
       // Ensure page with no items is returned for symbol not matching data
 
-      const pageThree = await tokenResolvers.tokenExchangeRates(['T5'], TokenExchangeRateFilter.price_high, 10, 0)
+      const pageThree = await tokenResolvers.tokenExchangeRates(['T5'], [], [], TokenExchangeRateFilter.price_high, 10, 0)
+      expect(pageThree).not.toBeNull()
+      expect(pageThree).toBeInstanceOf(TokenExchangeRatePageDto)
+      expect(pageThree).toHaveProperty('items')
+      expect(pageThree).toHaveProperty('totalCount', 0)
+      expect(pageThree.items).toHaveLength(0)
+
+    })
+
+    it('should filter by provided names array', async () => {
+
+      const pageOne = await tokenResolvers.tokenExchangeRates([], ['Token 3', 'Token 4'], [], TokenExchangeRateFilter.price_high, 10, 0)
+      expect(pageOne).not.toBeNull()
+      expect(pageOne).toBeInstanceOf(TokenExchangeRatePageDto)
+      expect(pageOne).toHaveProperty('items')
+      expect(pageOne).toHaveProperty('totalCount', 2)
+      expect(pageOne.items).toHaveLength(2)
+      expect(pageOne.items[0]).toHaveProperty('name', 'Token 4')
+      expect(pageOne.items[1]).toHaveProperty('name', 'Token 3')
+
+      const pageTwo = await tokenResolvers.tokenExchangeRates([], ['Token 1'], [], TokenExchangeRateFilter.price_high, 10, 0)
+      expect(pageTwo).not.toBeNull()
+      expect(pageTwo).toBeInstanceOf(TokenExchangeRatePageDto)
+      expect(pageTwo).toHaveProperty('items')
+      expect(pageTwo).toHaveProperty('totalCount', 1)
+      expect(pageTwo.items).toHaveLength(1)
+      expect(pageTwo.items[0]).toHaveProperty('name', 'Token 1')
+
+      expect(pageOne).not.toEqual(pageTwo)
+
+      // Ensure page with no items is returned for symbol not matching data
+
+      const pageThree = await tokenResolvers.tokenExchangeRates([], ['Token 5'], [], TokenExchangeRateFilter.price_high, 10, 0)
+      expect(pageThree).not.toBeNull()
+      expect(pageThree).toBeInstanceOf(TokenExchangeRatePageDto)
+      expect(pageThree).toHaveProperty('items')
+      expect(pageThree).toHaveProperty('totalCount', 0)
+      expect(pageThree.items).toHaveLength(0)
+
+    })
+
+    it('should filter by provided addresses array', async () => {
+
+      const pageOne = await tokenResolvers.tokenExchangeRates([], [], [contractAddressOne, contractAddressTwo], TokenExchangeRateFilter.price_high, 10, 0)
+      expect(pageOne).not.toBeNull()
+      expect(pageOne).toBeInstanceOf(TokenExchangeRatePageDto)
+      expect(pageOne).toHaveProperty('items')
+      expect(pageOne).toHaveProperty('totalCount', 2)
+      expect(pageOne.items).toHaveLength(2)
+      expect(pageOne.items[0]).toHaveProperty('address', contractAddressTwo)
+      expect(pageOne.items[1]).toHaveProperty('address', contractAddressOne)
+
+      const pageTwo = await tokenResolvers.tokenExchangeRates([], [], [contractAddressFour], TokenExchangeRateFilter.price_high, 10, 0)
+      expect(pageTwo).not.toBeNull()
+      expect(pageTwo).toBeInstanceOf(TokenExchangeRatePageDto)
+      expect(pageTwo).toHaveProperty('items')
+      expect(pageTwo).toHaveProperty('totalCount', 1)
+      expect(pageTwo.items).toHaveLength(1)
+      expect(pageTwo.items[0]).toHaveProperty('address', contractAddressFour)
+
+      expect(pageOne).not.toEqual(pageTwo)
+
+      // Ensure page with no items is returned for symbol not matching data
+
+      const pageThree = await tokenResolvers.tokenExchangeRates([], [], [contractAddressFive], TokenExchangeRateFilter.price_high, 10, 0)
       expect(pageThree).not.toBeNull()
       expect(pageThree).toBeInstanceOf(TokenExchangeRatePageDto)
       expect(pageThree).toHaveProperty('items')
@@ -589,7 +680,7 @@ describe('TokenResolvers', () => {
 
     it('should sort items array by the given sort parameter', async () => {
 
-      const priceHighPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 2, 0)
+      const priceHighPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 2, 0)
       expect(priceHighPage).not.toBeNull()
       expect(priceHighPage).toHaveProperty('items')
       expect(priceHighPage).toHaveProperty('totalCount', 4)
@@ -597,7 +688,7 @@ describe('TokenResolvers', () => {
       expect(priceHighPage.items[0]).toHaveProperty('currentPrice', 4)
       expect(priceHighPage.items[1]).toHaveProperty('currentPrice', 3)
 
-      const priceLowPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_low, 2, 0)
+      const priceLowPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_low, 2, 0)
       expect(priceLowPage).not.toBeNull()
       expect(priceLowPage).toHaveProperty('items')
       expect(priceLowPage).toHaveProperty('totalCount', 4)
@@ -605,7 +696,7 @@ describe('TokenResolvers', () => {
       expect(priceLowPage.items[0]).toHaveProperty('currentPrice', 1)
       expect(priceLowPage.items[1]).toHaveProperty('currentPrice', 2)
 
-      const volumeHighPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.volume_high, 2, 0)
+      const volumeHighPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.volume_high, 2, 0)
       expect(volumeHighPage).not.toBeNull()
       expect(volumeHighPage).toHaveProperty('items')
       expect(volumeHighPage).toHaveProperty('totalCount', 4)
@@ -613,7 +704,7 @@ describe('TokenResolvers', () => {
       expect(volumeHighPage.items[0]).toHaveProperty('totalVolume', 4000)
       expect(volumeHighPage.items[1]).toHaveProperty('totalVolume', 3000)
 
-      const volumeLowPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.volume_low, 2, 0)
+      const volumeLowPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.volume_low, 2, 0)
       expect(volumeLowPage).not.toBeNull()
       expect(volumeLowPage).toHaveProperty('items')
       expect(volumeLowPage).toHaveProperty('totalCount', 4)
@@ -621,7 +712,7 @@ describe('TokenResolvers', () => {
       expect(volumeLowPage.items[0]).toHaveProperty('totalVolume', 1000)
       expect(volumeLowPage.items[1]).toHaveProperty('totalVolume', 2000)
 
-      const marketCapHighPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.market_cap_high, 2, 0)
+      const marketCapHighPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.market_cap_high, 2, 0)
       expect(marketCapHighPage).not.toBeNull()
       expect(marketCapHighPage).toHaveProperty('items')
       expect(marketCapHighPage).toHaveProperty('totalCount', 4)
@@ -629,7 +720,7 @@ describe('TokenResolvers', () => {
       expect(marketCapHighPage.items[0]).toHaveProperty('marketCap', 10)
       expect(marketCapHighPage.items[1]).toHaveProperty('marketCap', 9)
 
-      const marketCapLowPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.market_cap_low, 2, 0)
+      const marketCapLowPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.market_cap_low, 2, 0)
       expect(marketCapLowPage).not.toBeNull()
       expect(marketCapLowPage).toHaveProperty('items')
       expect(marketCapLowPage).toHaveProperty('totalCount', 4)
@@ -637,7 +728,7 @@ describe('TokenResolvers', () => {
       expect(marketCapLowPage.items[0]).toHaveProperty('marketCap', 7)
       expect(marketCapLowPage.items[1]).toHaveProperty('marketCap', 8)
 
-      const marketCapRankPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.market_cap_rank, 2, 0)
+      const marketCapRankPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.market_cap_rank, 2, 0)
       expect(marketCapRankPage).not.toBeNull()
       expect(marketCapRankPage).toHaveProperty('items')
       expect(marketCapRankPage).toHaveProperty('totalCount', 4)
@@ -707,32 +798,106 @@ describe('TokenResolvers', () => {
   })
 
   describe('tokensMetadata', () => {
-    it('should return an array of TokenMetadataDto', async () => {
-      const metadata = await tokenResolvers.tokensMetadata(['T1', 'T2', 'T3'])
+    it('should return an instance of TokenMetadataPageDto with an array of items and totalCount', async () => {
+      const metadata = await tokenResolvers.tokensMetadata([])
       expect(metadata).not.toBeNull()
-      expect(metadata).toHaveLength(3)
-      expect(metadata[0]).toBeInstanceOf(TokenMetadataDto)
+      expect(metadata).toHaveProperty('totalCount', 3)
+      expect(metadata).toHaveProperty('items')
+      expect(metadata.items).toHaveLength(3)
+      expect(metadata.items[0]).toBeInstanceOf(TokenMetadataDto)
     })
 
     it('should return TokenMetadataDtos matching the symbols provided', async () => {
       const metadata = await tokenResolvers.tokensMetadata(['T1', 'T2'])
       expect(metadata).not.toBeNull()
-      expect(metadata).toHaveLength(2)
-      expect(metadata[0]).toHaveProperty('symbol', 'T1')
-      expect(metadata[1]).toHaveProperty('symbol', 'T2')
+      expect(metadata).toHaveProperty('totalCount', 2)
+      expect(metadata).toHaveProperty('items')
+      expect(metadata.items).toHaveLength(2)
+      expect(metadata.items[0]).toHaveProperty('symbol', 'T1')
+      expect(metadata.items[1]).toHaveProperty('symbol', 'T2')
 
       const metadataTwo = await tokenResolvers.tokensMetadata(['T3'])
       expect(metadataTwo).not.toBeNull()
-      expect(metadataTwo).toHaveLength(1)
-      expect(metadataTwo[0]).toHaveProperty('symbol', 'T3')
+      expect(metadataTwo).toHaveProperty('totalCount', 1)
+      expect(metadataTwo).toHaveProperty('items')
+      expect(metadataTwo.items).toHaveLength(1)
+      expect(metadataTwo.items[0]).toHaveProperty('symbol', 'T3')
 
       expect(metadata).not.toEqual(metadataTwo)
+
+      // Check an empty array is returned if no tokens match name provided
+      const metadataThree = await tokenResolvers.tokensMetadata(['Test'])
+      expect(metadataThree).not.toBeNull()
+      expect(metadataThree).toHaveProperty('totalCount', 0)
+      expect(metadataThree).toHaveProperty('items')
+      expect(metadataThree.items).toHaveLength(0)
     })
 
-    it('should return an empty array if no metadata is found matching symbols provided', async () => {
-      const metadata = await tokenResolvers.tokensMetadata(['T5'])
+    it('should return TokenMetadataDtos matching the names provided', async () => {
+      const metadata = await tokenResolvers.tokensMetadata([], ['Token 2', 'Token 3'])
       expect(metadata).not.toBeNull()
-      expect(metadata).toHaveLength(0)
+      expect(metadata).toHaveProperty('totalCount', 2)
+      expect(metadata).toHaveProperty('items')
+      expect(metadata.items).toHaveLength(2)
+      expect(metadata.items[0]).toHaveProperty('name', 'Token 2')
+      expect(metadata.items[1]).toHaveProperty('name', 'Token 3')
+
+      const metadataTwo = await tokenResolvers.tokensMetadata([], ['Token 1'])
+      expect(metadataTwo).not.toBeNull()
+      expect(metadataTwo).toHaveProperty('totalCount', 1)
+      expect(metadataTwo).toHaveProperty('items')
+      expect(metadataTwo.items).toHaveLength(1)
+      expect(metadataTwo.items[0]).toHaveProperty('name', 'Token 1')
+
+      expect(metadata).not.toEqual(metadataTwo)
+
+      // Check an empty array is returned if no tokens match name provided
+      const metadataThree = await tokenResolvers.tokensMetadata([], ['Token 4'])
+      expect(metadataThree).not.toBeNull()
+      expect(metadataThree).toHaveProperty('totalCount', 0)
+      expect(metadataThree).toHaveProperty('items')
+      expect(metadataThree.items).toHaveLength(0)
+    })
+
+    it('should return TokenMetadataDtos matching the addresses provided', async () => {
+      const metadata = await tokenResolvers.tokensMetadata([], [], [contractAddressOne, contractAddressTwo])
+      expect(metadata).not.toBeNull()
+      expect(metadata).toHaveProperty('totalCount', 2)
+      expect(metadata).toHaveProperty('items')
+      expect(metadata.items).toHaveLength(2)
+      expect(metadata.items[0]).toHaveProperty('address', contractAddressOne)
+      expect(metadata.items[1]).toHaveProperty('address', contractAddressTwo)
+
+      const metadataTwo = await tokenResolvers.tokensMetadata([], [], [contractAddressThree])
+      expect(metadataTwo).not.toBeNull()
+      expect(metadataTwo).toHaveProperty('totalCount', 1)
+      expect(metadataTwo).toHaveProperty('items')
+      expect(metadataTwo.items).toHaveLength(1)
+      expect(metadataTwo.items[0]).toHaveProperty('address', contractAddressThree)
+
+      expect(metadata).not.toEqual(metadataTwo)
+
+      // Check an empty array is returned if no tokens match address provided
+      const metadataThree = await tokenResolvers.tokensMetadata([], [], [contractAddressFive])
+      expect(metadataThree).not.toBeNull()
+      expect(metadataThree).toHaveProperty('totalCount', 0)
+      expect(metadataThree).toHaveProperty('items')
+      expect(metadataThree.items).toHaveLength(0)
+    })
+    it('should respect limit and offset parameters', async () => {
+      const pageOne = await tokenResolvers.tokensMetadata([], [], [], 0, 2)
+      expect(pageOne).not.toBeNull()
+      expect(pageOne).toHaveProperty('totalCount', 3)
+      expect(pageOne).toHaveProperty('items')
+      expect(pageOne.items).toHaveLength(2)
+
+      const pageTwo = await tokenResolvers.tokensMetadata([], [], [], 2, 2)
+      expect(pageTwo).not.toBeNull()
+      expect(pageTwo).toHaveProperty('totalCount', 3)
+      expect(pageTwo).toHaveProperty('items')
+      expect(pageTwo.items).toHaveLength(1)
+
+      expect(pageOne).not.toEqual(pageTwo)
     })
   })
 

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -3,7 +3,6 @@ import { ParseAddressPipe } from '@app/shared/validation/parse-address.pipe'
 import { TokenService } from '@app/dao/token.service'
 import { TokenHolderDto } from '@app/graphql/tokens/dto/token-holder.dto'
 import { TokenExchangeRateDto } from '@app/graphql/tokens/dto/token-exchange-rate.dto'
-import { TokenMetadataDto } from '@app/graphql/tokens/dto/token-metadata.dto'
 import { TokenHoldersPageDto } from '@app/graphql/tokens/dto/token-holders-page.dto'
 import { TokenPageDto } from '@app/graphql/tokens/dto/token-page.dto'
 import BigNumber from 'bignumber.js'
@@ -11,6 +10,7 @@ import { TokenExchangeRatePageDto } from '@app/graphql/tokens/dto/token-exchange
 import { CoinExchangeRateDto } from '@app/graphql/tokens/dto/coin-exchange-rate.dto'
 import { UseInterceptors } from '@nestjs/common'
 import { SyncingInterceptor } from '@app/shared/interceptors/syncing-interceptor'
+import { TokenMetadataPageDto } from '@app/graphql/tokens/dto/token-metadata-page.dto'
 import { TokenDetailDto } from '@app/graphql/tokens/dto/token-detail.dto'
 
 @Resolver('Token')
@@ -66,12 +66,14 @@ export class TokenResolvers {
 
   @Query()
   async tokenExchangeRates(
-    @Args({ name: 'symbols', type: () => [String] }) symbols: string[],
-    @Args('sort') sort: string,
-    @Args('limit') limit: number,
-    @Args('offset') offset: number,
+    @Args({ name: 'symbols', type: () => [String], nullable: true }) symbols?: string[],
+    @Args({ name: 'names', type: () => [String], nullable: true }) names?: string[],
+    @Args({ name: 'addresses', type: () => [String], nullable: true }) addresses?: string[],
+    @Args('sort') sort?: string,
+    @Args('limit') limit?: number,
+    @Args('offset') offset?: number,
   ): Promise<TokenExchangeRatePageDto> {
-    const [items, totalCount] = await this.tokenService.findTokenExchangeRates(sort, limit, offset, symbols)
+    const [items, totalCount] = await this.tokenService.findTokenExchangeRates(sort, limit, offset, symbols, names, addresses)
     return new TokenExchangeRatePageDto({ items, totalCount })
   }
 
@@ -95,8 +97,15 @@ export class TokenResolvers {
   }
 
   @Query()
-  async tokensMetadata(@Args({name: 'symbols', type: () => [String]}) symbols: string[]): Promise<TokenMetadataDto[]> {
-    return await this.tokenService.findTokensMetadata(symbols)
+  async tokensMetadata(
+    @Args({ name: 'symbols', type: () => [String], nullable: true }) symbols?: string[],
+    @Args({ name: 'names', type: () => [String], nullable: true }) names?: string[],
+    @Args({ name: 'addresses', type: () => [String], nullable: true }) addresses?: string[],
+    @Args('offset') offset?: number,
+    @Args('limit') limit?: number,
+  ): Promise<TokenMetadataPageDto> {
+    const [items, totalCount] = await this.tokenService.findTokensMetadata(symbols, names, addresses, offset, limit)
+    return new TokenMetadataPageDto({ items, totalCount })
   }
 
   @Query()

--- a/apps/api/src/orm/entities/token-metadata.entity.ts
+++ b/apps/api/src/orm/entities/token-metadata.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm'
+import { assignClean } from '@app/shared/utils'
+
+@Entity('token_metadata')
+export class TokenMetadataEntity {
+
+  constructor(data: any) {
+    assignClean(this, data);
+  }
+
+  @PrimaryColumn({ type: 'character varying', readonly: true })
+  address!: string
+
+  @Column({ type: 'character varying', readonly: true })
+  name?: string
+
+  @Column({ type: 'character varying', readonly: true })
+  symbol?: string
+
+  @Column({ type: 'character varying', readonly: true })
+  website?: string
+
+  @Column({ type: 'text', readonly: true })
+  logo?: string
+
+  @Column({ type: 'text', readonly: true })
+  support?: string
+
+  @Column({ type: 'integer', readonly: true })
+  decimals?: string
+
+}

--- a/apps/migrator/migrations/principal/R__Indexes.sql
+++ b/apps/migrator/migrations/principal/R__Indexes.sql
@@ -88,3 +88,7 @@ CREATE INDEX IF NOT EXISTS idx_contract_created_creator ON contract_created (cre
 CREATE INDEX IF NOT EXISTS idx_contract_created_contract_type ON contract_created (contract_type);
 CREATE INDEX IF NOT EXISTS idx_contract_created_trace_location_block_hash ON contract_created (trace_location_block_hash);
 CREATE INDEX IF NOT EXISTS idx_contract_destroyed_trace_location_block_hash ON contract_created (trace_location_block_hash);
+
+/* Token */
+CREATE INDEX IF NOT EXISTS idx_token_exchange_rates_name ON token_exchange_rates (name);
+CREATE INDEX IF NOT EXISTS idx_token_exchange_rates_symbol ON token_exchange_rates (symbol);

--- a/apps/migrator/migrations/principal/V7__Create_token_metadata_view.sql
+++ b/apps/migrator/migrations/principal/V7__Create_token_metadata_view.sql
@@ -1,6 +1,3 @@
-CREATE INDEX idx_token_exchange_rates_name ON token_exchange_rates (name);
-CREATE INDEX idx_token_exchange_rates_symbol ON token_exchange_rates (symbol);
-
 /* create token_search_result view for sorting erc20 and erc721 tokens matching a query string */
 CREATE VIEW token_metadata AS
 SELECT  e20.name AS name,

--- a/apps/migrator/migrations/principal/initial/V4__Create_token_views.sql
+++ b/apps/migrator/migrations/principal/initial/V4__Create_token_views.sql
@@ -1,0 +1,26 @@
+CREATE INDEX idx_token_exchange_rates_name ON token_exchange_rates (name);
+CREATE INDEX idx_token_exchange_rates_symbol ON token_exchange_rates (symbol);
+
+/* create token_search_result view for sorting erc20 and erc721 tokens matching a query string */
+CREATE VIEW token_metadata AS
+SELECT  e20.name AS name,
+        e20.symbol AS symbol,
+        e20.address AS address,
+        e20.decimals AS decimals,
+        elcm.website AS website,
+        elcm.logo AS logo,
+        elcm.support AS support,
+        'erc20' AS type
+FROM erc20_metadata AS e20
+        LEFT JOIN eth_list_contract_metadata AS elcm ON elcm.address = e20.address
+UNION ALL
+SELECT  e721.name,
+        e721.symbol,
+        e721.address,
+        NULL,
+        elcm2.website,
+        elcm2.logo,
+        elcm2.support,
+        'erc721' AS type
+FROM erc721_metadata AS e721
+        LEFT JOIN eth_list_contract_metadata AS elcm2 ON elcm2.address = e721.address;


### PR DESCRIPTION
Extends both tokenExchangeRates and tokensMetadata to be able to query by not only an array of symbols, but also an array of names or an array of addresses (or a combination of the three or none at all). TokensMetadata query now returns a page of items and accept offset and limit params.

This includes a new migration to db-principal which adds an extra view and two new indexes. Adding @brianmcgee to review this before merging. 