### PR TITLE
Fix/ Canonical token exchange rates view

### DIFF
--- a/apps/migrator/migrations/principal/V8__Fix_canonical_token_exchange_rates_view.sql
+++ b/apps/migrator/migrations/principal/V8__Fix_canonical_token_exchange_rates_view.sql
@@ -1,0 +1,7 @@
+DROP VIEW canonical_token_exchange_rates;
+
+CREATE VIEW canonical_token_exchange_rates AS
+SELECT ter.*
+FROM token_exchange_rates AS ter
+       INNER JOIN canonical_contract AS cc on ter.address = cc.address
+       WHERE cc.contract_type = 'ERC20';


### PR DESCRIPTION
Replaces canonical_token_exchange_rates with the same view except further filtered by where token_exchange_rates items have a contract relation with type = 'ERC20'