### PR TITLE
Fix/remove symbols and names params from token queries

### DIFF
--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -7,7 +7,7 @@ import { Erc721MetadataEntity } from '@app/orm/entities/erc721-metadata.entity'
 import { TokenExchangeRateEntity } from '@app/orm/entities/token-exchange-rate.entity'
 import { Injectable } from '@nestjs/common'
 import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm'
-import { Any, EntityManager, FindManyOptions, FindOneOptions, Not, Repository } from 'typeorm'
+import { Any, EntityManager, FindManyOptions, FindOneOptions, Repository } from 'typeorm'
 import BigNumber from 'bignumber.js'
 import { DbConnection } from '@app/orm/config'
 import { TokenMetadataEntity } from '@app/orm/entities/token-metadata.entity'
@@ -179,28 +179,21 @@ export class TokenService {
   }
 
   async findTokensMetadata(
-    symbols: string[] = [],
-    names: string[] = [],
     addresses: string[] = [],
     offset: number = 0,
     limit: number = 20,
   ): Promise<[TokenMetadataEntity[], number]> {
-    const where: any[] = []
-    if (symbols.length) {
-      where.push({ symbol: Any(symbols) })
-    }
-    if (names.length) {
-      where.push({ name: Any(names) })
-    }
-    if (addresses.length) {
-      where.push({ address: Any(addresses) })
-    }
-    const findOptions = {
-      where,
+
+    const findOptions: FindManyOptions = {
       take: limit,
       skip: offset,
       cache: true,
     }
+
+    if (addresses.length) {
+      findOptions.where = { address: Any(addresses) }
+    }
+
     return await this.tokenMetadataRepository.findAndCount(findOptions)
   }
 

--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -96,8 +96,6 @@ export class TokenService {
     sort: string = 'market_cap_rank',
     limit: number = 10,
     offset: number = 0,
-    symbols: string[] = [],
-    names: string[] = [],
     addresses: string[] = [],
   ): Promise<[TokenExchangeRateEntity[], number]> {
     let order
@@ -126,24 +124,17 @@ export class TokenService {
         break
     }
 
-    const where = [] as any[]
-    if (symbols.length) {
-      where.push({symbol: Any(symbols)})
-    }
-    if (names.length) {
-      where.push({name: Any(names)})
-    }
-    if (addresses.length) {
-      where.push({address: Any(addresses)})
-    }
-
     const findOptions: FindManyOptions = {
-      where,
       order,
       take: limit,
       skip: offset,
       cache: true,
     }
+
+    if (addresses.length) {
+      findOptions.where = {address: Any(addresses)}
+    }
+
     return this.tokenExchangeRateRepository.findAndCount(findOptions)
   }
 

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -339,7 +339,7 @@ export interface IQuery {
     totalNumTokenExchangeRates(): number | Promise<number>;
     tokenExchangeRateBySymbol(symbol: string): TokenExchangeRate | Promise<TokenExchangeRate>;
     tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;
-    tokensMetadata(symbols?: string[], names?: string[], addresses?: string[], offset?: number, limit?: number): TokenMetadataPage | Promise<TokenMetadataPage>;
+    tokensMetadata(addresses?: string[], offset?: number, limit?: number): TokenMetadataPage | Promise<TokenMetadataPage>;
     tokenHolders(address: string, offset?: number, limit?: number): TokenHoldersPage | Promise<TokenHoldersPage>;
     tokenDetailByAddress(address: string): TokenDetail | Promise<TokenDetail>;
     tokenTransfersByContractAddressesForHolder(contractAddresses: string[], holderAddress: string, filter?: FilterEnum, limit?: number, page?: number, timestampFrom?: number, timestampTo?: number): TransferPage | Promise<TransferPage>;

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -335,7 +335,7 @@ export interface IQuery {
     addressAllTokensOwned(address: string, offset?: number, limit?: number): TokenBalancePage | Promise<TokenBalancePage>;
     addressTotalTokenValueUSD(address: string): BigNumber | Promise<BigNumber>;
     coinExchangeRate(pair: ExchangeRatePair): CoinExchangeRate | Promise<CoinExchangeRate>;
-    tokenExchangeRates(symbols?: string[], names?: string[], addresses?: string[], sort?: TokenExchangeRateFilter, offset?: number, limit?: number): TokenExchangeRatesPage | Promise<TokenExchangeRatesPage>;
+    tokenExchangeRates(addresses?: string[], sort?: TokenExchangeRateFilter, offset?: number, limit?: number): TokenExchangeRatesPage | Promise<TokenExchangeRatesPage>;
     totalNumTokenExchangeRates(): number | Promise<number>;
     tokenExchangeRateBySymbol(symbol: string): TokenExchangeRate | Promise<TokenExchangeRate>;
     tokenExchangeRateByAddress(address: string): TokenExchangeRate | Promise<TokenExchangeRate>;

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -7,7 +7,7 @@ type Query {
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
   tokenExchangeRateByAddress(address: String!): TokenExchangeRate
-  tokensMetadata(symbols: [String], names: [String], addresses: [String], offset: Int = 0, limit: Int = 20): TokenMetadataPage!
+  tokensMetadata(addresses: [String], offset: Int = 0, limit: Int = 20): TokenMetadataPage!
   tokenHolders(address: String!, offset: Int = 0, limit: Int = 20): TokenHoldersPage!
   tokenDetailByAddress(address: String!): TokenDetail
 }

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -3,7 +3,7 @@ type Query {
   addressAllTokensOwned(address: String!, offset: Int = 0, limit: Int = 10): TokenBalancePage!
   addressTotalTokenValueUSD(address: String!): BigNumber
   coinExchangeRate(pair: ExchangeRatePair!): CoinExchangeRate
-  tokenExchangeRates(symbols: [String], names: [String], addresses: [String], sort: TokenExchangeRateFilter, offset: Int = 0, limit: Int = 20): TokenExchangeRatesPage!
+  tokenExchangeRates(addresses: [String], sort: TokenExchangeRateFilter, offset: Int = 0, limit: Int = 20): TokenExchangeRatesPage!
   totalNumTokenExchangeRates: Int!
   tokenExchangeRateBySymbol(symbol: String!): TokenExchangeRate
   tokenExchangeRateByAddress(address: String!): TokenExchangeRate

--- a/apps/api/src/graphql/tokens/token.resolvers.spec.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.spec.ts
@@ -212,14 +212,12 @@ const tokenServiceMock = {
     sort: string = 'market_cap_rank',
     limit: number = 10,
     offset: number = 0,
-    symbols: string[] = [],
-    names: string[] = [],
     addresses: string[] = [],
   ): Promise<[TokenExchangeRateEntity[], number]> {
 
     // Filter by symbol if set
-    let items = symbols.length || names.length || addresses.length ?
-      tokenExchangeRates.filter(t => symbols.includes(t.symbol!) || names.includes(t.name!) || addresses.includes(t.address)) :
+    let items = addresses.length ?
+      tokenExchangeRates.filter(t => addresses.includes(t.address)) :
       tokenExchangeRates
 
     // Total count
@@ -540,7 +538,7 @@ describe('TokenResolvers', () => {
   describe('tokenExchangeRates', () => {
     it('should return an instance of TokenExchangeRatePageDto with items and totalCount', async () => {
 
-      const tokenExchangeRatesPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 10, 0)
+      const tokenExchangeRatesPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 10, 0)
 
       expect(tokenExchangeRatesPage).not.toBeNull()
       expect(tokenExchangeRatesPage).toBeInstanceOf(TokenExchangeRatePageDto)
@@ -553,7 +551,7 @@ describe('TokenResolvers', () => {
 
     it('should respect given offset and limit parameters', async () => {
 
-      const pageOne = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 2, 0)
+      const pageOne = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 2, 0)
 
       expect(pageOne).not.toBeNull()
       expect(pageOne).toBeInstanceOf(TokenExchangeRatePageDto)
@@ -566,7 +564,7 @@ describe('TokenResolvers', () => {
       expect(pageOne.items[1]).toHaveProperty('address', contractAddressThree)
       expect(pageOne.items[1]).toHaveProperty('currentPrice', new BigNumber(3))
 
-      const pageTwo = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 2, 2)
+      const pageTwo = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 2, 2)
 
       expect(pageTwo).not.toBeNull()
       expect(pageTwo).toBeInstanceOf(TokenExchangeRatePageDto)
@@ -584,7 +582,7 @@ describe('TokenResolvers', () => {
 
       // Check an empty array is returned if offset >= totalCount
 
-      const pageThree = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 2, 4)
+      const pageThree = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 2, 4)
 
       expect(pageThree).not.toBeNull()
       expect(pageThree).toBeInstanceOf(TokenExchangeRatePageDto)
@@ -593,73 +591,9 @@ describe('TokenResolvers', () => {
       expect(pageThree.items).toHaveLength(0)
     })
 
-    it('should filter by provided symbols array', async () => {
-
-      const pageOne = await tokenResolvers.tokenExchangeRates(['T1', 'T2'], [], [], TokenExchangeRateFilter.price_high, 10, 0)
-      expect(pageOne).not.toBeNull()
-      expect(pageOne).toBeInstanceOf(TokenExchangeRatePageDto)
-      expect(pageOne).toHaveProperty('items')
-      expect(pageOne).toHaveProperty('totalCount', 2)
-      expect(pageOne.items).toHaveLength(2)
-      expect(pageOne.items[0]).toHaveProperty('symbol', 'T2')
-      expect(pageOne.items[1]).toHaveProperty('symbol', 'T1')
-
-      const pageTwo = await tokenResolvers.tokenExchangeRates(['T3'], [], [], TokenExchangeRateFilter.price_high, 10, 0)
-      expect(pageTwo).not.toBeNull()
-      expect(pageTwo).toBeInstanceOf(TokenExchangeRatePageDto)
-      expect(pageTwo).toHaveProperty('items')
-      expect(pageTwo).toHaveProperty('totalCount', 1)
-      expect(pageTwo.items).toHaveLength(1)
-      expect(pageTwo.items[0]).toHaveProperty('symbol', 'T3')
-
-      expect(pageOne).not.toEqual(pageTwo)
-
-      // Ensure page with no items is returned for symbol not matching data
-
-      const pageThree = await tokenResolvers.tokenExchangeRates(['T5'], [], [], TokenExchangeRateFilter.price_high, 10, 0)
-      expect(pageThree).not.toBeNull()
-      expect(pageThree).toBeInstanceOf(TokenExchangeRatePageDto)
-      expect(pageThree).toHaveProperty('items')
-      expect(pageThree).toHaveProperty('totalCount', 0)
-      expect(pageThree.items).toHaveLength(0)
-
-    })
-
-    it('should filter by provided names array', async () => {
-
-      const pageOne = await tokenResolvers.tokenExchangeRates([], ['Token 3', 'Token 4'], [], TokenExchangeRateFilter.price_high, 10, 0)
-      expect(pageOne).not.toBeNull()
-      expect(pageOne).toBeInstanceOf(TokenExchangeRatePageDto)
-      expect(pageOne).toHaveProperty('items')
-      expect(pageOne).toHaveProperty('totalCount', 2)
-      expect(pageOne.items).toHaveLength(2)
-      expect(pageOne.items[0]).toHaveProperty('name', 'Token 4')
-      expect(pageOne.items[1]).toHaveProperty('name', 'Token 3')
-
-      const pageTwo = await tokenResolvers.tokenExchangeRates([], ['Token 1'], [], TokenExchangeRateFilter.price_high, 10, 0)
-      expect(pageTwo).not.toBeNull()
-      expect(pageTwo).toBeInstanceOf(TokenExchangeRatePageDto)
-      expect(pageTwo).toHaveProperty('items')
-      expect(pageTwo).toHaveProperty('totalCount', 1)
-      expect(pageTwo.items).toHaveLength(1)
-      expect(pageTwo.items[0]).toHaveProperty('name', 'Token 1')
-
-      expect(pageOne).not.toEqual(pageTwo)
-
-      // Ensure page with no items is returned for symbol not matching data
-
-      const pageThree = await tokenResolvers.tokenExchangeRates([], ['Token 5'], [], TokenExchangeRateFilter.price_high, 10, 0)
-      expect(pageThree).not.toBeNull()
-      expect(pageThree).toBeInstanceOf(TokenExchangeRatePageDto)
-      expect(pageThree).toHaveProperty('items')
-      expect(pageThree).toHaveProperty('totalCount', 0)
-      expect(pageThree.items).toHaveLength(0)
-
-    })
-
     it('should filter by provided addresses array', async () => {
 
-      const pageOne = await tokenResolvers.tokenExchangeRates([], [], [contractAddressOne, contractAddressTwo], TokenExchangeRateFilter.price_high, 10, 0)
+      const pageOne = await tokenResolvers.tokenExchangeRates([contractAddressOne, contractAddressTwo], TokenExchangeRateFilter.price_high, 10, 0)
       expect(pageOne).not.toBeNull()
       expect(pageOne).toBeInstanceOf(TokenExchangeRatePageDto)
       expect(pageOne).toHaveProperty('items')
@@ -668,7 +602,7 @@ describe('TokenResolvers', () => {
       expect(pageOne.items[0]).toHaveProperty('address', contractAddressTwo)
       expect(pageOne.items[1]).toHaveProperty('address', contractAddressOne)
 
-      const pageTwo = await tokenResolvers.tokenExchangeRates([], [], [contractAddressFour], TokenExchangeRateFilter.price_high, 10, 0)
+      const pageTwo = await tokenResolvers.tokenExchangeRates([contractAddressFour], TokenExchangeRateFilter.price_high, 10, 0)
       expect(pageTwo).not.toBeNull()
       expect(pageTwo).toBeInstanceOf(TokenExchangeRatePageDto)
       expect(pageTwo).toHaveProperty('items')
@@ -680,7 +614,7 @@ describe('TokenResolvers', () => {
 
       // Ensure page with no items is returned for symbol not matching data
 
-      const pageThree = await tokenResolvers.tokenExchangeRates([], [], [contractAddressFive], TokenExchangeRateFilter.price_high, 10, 0)
+      const pageThree = await tokenResolvers.tokenExchangeRates([contractAddressFive], TokenExchangeRateFilter.price_high, 10, 0)
       expect(pageThree).not.toBeNull()
       expect(pageThree).toBeInstanceOf(TokenExchangeRatePageDto)
       expect(pageThree).toHaveProperty('items')
@@ -691,7 +625,7 @@ describe('TokenResolvers', () => {
 
     it('should sort items array by the given sort parameter', async () => {
 
-      const priceHighPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_high, 2, 0)
+      const priceHighPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_high, 2, 0)
       expect(priceHighPage).not.toBeNull()
       expect(priceHighPage).toHaveProperty('items')
       expect(priceHighPage).toHaveProperty('totalCount', 4)
@@ -699,7 +633,7 @@ describe('TokenResolvers', () => {
       expect(priceHighPage.items[0]).toHaveProperty('currentPrice', new BigNumber(4))
       expect(priceHighPage.items[1]).toHaveProperty('currentPrice', new BigNumber(3))
 
-      const priceLowPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.price_low, 2, 0)
+      const priceLowPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.price_low, 2, 0)
       expect(priceLowPage).not.toBeNull()
       expect(priceLowPage).toHaveProperty('items')
       expect(priceLowPage).toHaveProperty('totalCount', 4)
@@ -707,7 +641,7 @@ describe('TokenResolvers', () => {
       expect(priceLowPage.items[0]).toHaveProperty('currentPrice', new BigNumber(1))
       expect(priceLowPage.items[1]).toHaveProperty('currentPrice', new BigNumber(2))
 
-      const volumeHighPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.volume_high, 2, 0)
+      const volumeHighPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.volume_high, 2, 0)
       expect(volumeHighPage).not.toBeNull()
       expect(volumeHighPage).toHaveProperty('items')
       expect(volumeHighPage).toHaveProperty('totalCount', 4)
@@ -715,7 +649,7 @@ describe('TokenResolvers', () => {
       expect(volumeHighPage.items[0]).toHaveProperty('totalVolume', new BigNumber(4000))
       expect(volumeHighPage.items[1]).toHaveProperty('totalVolume', new BigNumber(3000))
 
-      const volumeLowPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.volume_low, 2, 0)
+      const volumeLowPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.volume_low, 2, 0)
       expect(volumeLowPage).not.toBeNull()
       expect(volumeLowPage).toHaveProperty('items')
       expect(volumeLowPage).toHaveProperty('totalCount', 4)
@@ -723,7 +657,7 @@ describe('TokenResolvers', () => {
       expect(volumeLowPage.items[0]).toHaveProperty('totalVolume', new BigNumber(1000))
       expect(volumeLowPage.items[1]).toHaveProperty('totalVolume', new BigNumber(2000))
 
-      const marketCapHighPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.market_cap_high, 2, 0)
+      const marketCapHighPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.market_cap_high, 2, 0)
       expect(marketCapHighPage).not.toBeNull()
       expect(marketCapHighPage).toHaveProperty('items')
       expect(marketCapHighPage).toHaveProperty('totalCount', 4)
@@ -731,7 +665,7 @@ describe('TokenResolvers', () => {
       expect(marketCapHighPage.items[0]).toHaveProperty('marketCap', new BigNumber(10))
       expect(marketCapHighPage.items[1]).toHaveProperty('marketCap', new BigNumber(9))
 
-      const marketCapLowPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.market_cap_low, 2, 0)
+      const marketCapLowPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.market_cap_low, 2, 0)
       expect(marketCapLowPage).not.toBeNull()
       expect(marketCapLowPage).toHaveProperty('items')
       expect(marketCapLowPage).toHaveProperty('totalCount', 4)
@@ -739,7 +673,7 @@ describe('TokenResolvers', () => {
       expect(marketCapLowPage.items[0]).toHaveProperty('marketCap', new BigNumber(7))
       expect(marketCapLowPage.items[1]).toHaveProperty('marketCap', new BigNumber(8))
 
-      const marketCapRankPage = await tokenResolvers.tokenExchangeRates([], [], [], TokenExchangeRateFilter.market_cap_rank, 2, 0)
+      const marketCapRankPage = await tokenResolvers.tokenExchangeRates([], TokenExchangeRateFilter.market_cap_rank, 2, 0)
       expect(marketCapRankPage).not.toBeNull()
       expect(marketCapRankPage).toHaveProperty('items')
       expect(marketCapRankPage).toHaveProperty('totalCount', 4)
@@ -818,60 +752,8 @@ describe('TokenResolvers', () => {
       expect(metadata.items[0]).toBeInstanceOf(TokenMetadataDto)
     })
 
-    it('should return TokenMetadataDtos matching the symbols provided', async () => {
-      const metadata = await tokenResolvers.tokensMetadata(['T1', 'T2'])
-      expect(metadata).not.toBeNull()
-      expect(metadata).toHaveProperty('totalCount', 2)
-      expect(metadata).toHaveProperty('items')
-      expect(metadata.items).toHaveLength(2)
-      expect(metadata.items[0]).toHaveProperty('symbol', 'T1')
-      expect(metadata.items[1]).toHaveProperty('symbol', 'T2')
-
-      const metadataTwo = await tokenResolvers.tokensMetadata(['T3'])
-      expect(metadataTwo).not.toBeNull()
-      expect(metadataTwo).toHaveProperty('totalCount', 1)
-      expect(metadataTwo).toHaveProperty('items')
-      expect(metadataTwo.items).toHaveLength(1)
-      expect(metadataTwo.items[0]).toHaveProperty('symbol', 'T3')
-
-      expect(metadata).not.toEqual(metadataTwo)
-
-      // Check an empty array is returned if no tokens match name provided
-      const metadataThree = await tokenResolvers.tokensMetadata(['Test'])
-      expect(metadataThree).not.toBeNull()
-      expect(metadataThree).toHaveProperty('totalCount', 0)
-      expect(metadataThree).toHaveProperty('items')
-      expect(metadataThree.items).toHaveLength(0)
-    })
-
-    it('should return TokenMetadataDtos matching the names provided', async () => {
-      const metadata = await tokenResolvers.tokensMetadata([], ['Token 2', 'Token 3'])
-      expect(metadata).not.toBeNull()
-      expect(metadata).toHaveProperty('totalCount', 2)
-      expect(metadata).toHaveProperty('items')
-      expect(metadata.items).toHaveLength(2)
-      expect(metadata.items[0]).toHaveProperty('name', 'Token 2')
-      expect(metadata.items[1]).toHaveProperty('name', 'Token 3')
-
-      const metadataTwo = await tokenResolvers.tokensMetadata([], ['Token 1'])
-      expect(metadataTwo).not.toBeNull()
-      expect(metadataTwo).toHaveProperty('totalCount', 1)
-      expect(metadataTwo).toHaveProperty('items')
-      expect(metadataTwo.items).toHaveLength(1)
-      expect(metadataTwo.items[0]).toHaveProperty('name', 'Token 1')
-
-      expect(metadata).not.toEqual(metadataTwo)
-
-      // Check an empty array is returned if no tokens match name provided
-      const metadataThree = await tokenResolvers.tokensMetadata([], ['Token 4'])
-      expect(metadataThree).not.toBeNull()
-      expect(metadataThree).toHaveProperty('totalCount', 0)
-      expect(metadataThree).toHaveProperty('items')
-      expect(metadataThree.items).toHaveLength(0)
-    })
-
     it('should return TokenMetadataDtos matching the addresses provided', async () => {
-      const metadata = await tokenResolvers.tokensMetadata([], [], [contractAddressOne, contractAddressTwo])
+      const metadata = await tokenResolvers.tokensMetadata([contractAddressOne, contractAddressTwo])
       expect(metadata).not.toBeNull()
       expect(metadata).toHaveProperty('totalCount', 2)
       expect(metadata).toHaveProperty('items')
@@ -879,7 +761,7 @@ describe('TokenResolvers', () => {
       expect(metadata.items[0]).toHaveProperty('address', contractAddressOne)
       expect(metadata.items[1]).toHaveProperty('address', contractAddressTwo)
 
-      const metadataTwo = await tokenResolvers.tokensMetadata([], [], [contractAddressThree])
+      const metadataTwo = await tokenResolvers.tokensMetadata([contractAddressThree])
       expect(metadataTwo).not.toBeNull()
       expect(metadataTwo).toHaveProperty('totalCount', 1)
       expect(metadataTwo).toHaveProperty('items')
@@ -889,20 +771,20 @@ describe('TokenResolvers', () => {
       expect(metadata).not.toEqual(metadataTwo)
 
       // Check an empty array is returned if no tokens match address provided
-      const metadataThree = await tokenResolvers.tokensMetadata([], [], [contractAddressFive])
+      const metadataThree = await tokenResolvers.tokensMetadata([contractAddressFive])
       expect(metadataThree).not.toBeNull()
       expect(metadataThree).toHaveProperty('totalCount', 0)
       expect(metadataThree).toHaveProperty('items')
       expect(metadataThree.items).toHaveLength(0)
     })
     it('should respect limit and offset parameters', async () => {
-      const pageOne = await tokenResolvers.tokensMetadata([], [], [], 0, 2)
+      const pageOne = await tokenResolvers.tokensMetadata([], 0, 2)
       expect(pageOne).not.toBeNull()
       expect(pageOne).toHaveProperty('totalCount', 3)
       expect(pageOne).toHaveProperty('items')
       expect(pageOne.items).toHaveLength(2)
 
-      const pageTwo = await tokenResolvers.tokensMetadata([], [], [], 2, 2)
+      const pageTwo = await tokenResolvers.tokensMetadata([], 2, 2)
       expect(pageTwo).not.toBeNull()
       expect(pageTwo).toHaveProperty('totalCount', 3)
       expect(pageTwo).toHaveProperty('items')

--- a/apps/api/src/graphql/tokens/token.resolvers.spec.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.spec.ts
@@ -270,14 +270,12 @@ const tokenServiceMock = {
     return erc20Balances.filter(e => e.contract === address).length
   },
   async findTokensMetadata(
-    symbols: string[] = [],
-    names: string[] = [],
     addresses: string[] = [],
     offset: number = 0,
     limit: number = 20,
   ): Promise<[TokenMetadataEntity[], number]> {
-    let items = symbols.length || names.length || addresses.length ?
-      tokenMetadata.filter(t => symbols.includes(t.symbol!) || names.includes(t.name!) || addresses.includes(t.address)) :
+    let items = addresses.length ?
+      tokenMetadata.filter(t => addresses.includes(t.address)) :
       tokenMetadata
 
     const totalCount = items.length

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -96,13 +96,11 @@ export class TokenResolvers {
 
   @Query()
   async tokensMetadata(
-    @Args({ name: 'symbols', type: () => [String], nullable: true }) symbols?: string[],
-    @Args({ name: 'names', type: () => [String], nullable: true }) names?: string[],
     @Args({ name: 'addresses', type: () => [String], nullable: true }) addresses?: string[],
     @Args('offset') offset?: number,
     @Args('limit') limit?: number,
   ): Promise<TokenMetadataPageDto> {
-    const [items, totalCount] = await this.tokenService.findTokensMetadata(symbols, names, addresses, offset, limit)
+    const [items, totalCount] = await this.tokenService.findTokensMetadata(addresses, offset, limit)
     return new TokenMetadataPageDto({ items, totalCount })
   }
 

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -66,14 +66,12 @@ export class TokenResolvers {
 
   @Query()
   async tokenExchangeRates(
-    @Args({ name: 'symbols', type: () => [String], nullable: true }) symbols?: string[],
-    @Args({ name: 'names', type: () => [String], nullable: true }) names?: string[],
     @Args({ name: 'addresses', type: () => [String], nullable: true }) addresses?: string[],
     @Args('sort') sort?: string,
     @Args('limit') limit?: number,
     @Args('offset') offset?: number,
   ): Promise<TokenExchangeRatePageDto> {
-    const [items, totalCount] = await this.tokenService.findTokenExchangeRates(sort, limit, offset, symbols, names, addresses)
+    const [items, totalCount] = await this.tokenService.findTokenExchangeRates(sort, limit, offset, addresses)
     return new TokenExchangeRatePageDto({ items, totalCount })
   }
 

--- a/apps/explorer/apollo/schemas/api.json
+++ b/apps/explorer/apollo/schemas/api.json
@@ -643,34 +643,6 @@
             "description": null,
             "args": [
               {
-                "name": "symbols",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "names",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
                 "name": "addresses",
                 "description": null,
                 "type": {


### PR DESCRIPTION
Removes symbols and names params from:
- tokenExchangeRates()
- tokensMetadata()