### PR TITLE
Feature/sanitize hash and address param strings to lower case

### DIFF
--- a/apps/api/src/dao/search.service.ts
+++ b/apps/api/src/dao/search.service.ts
@@ -30,7 +30,7 @@ export class SearchService {
 
     // Check Accounts
     if (this.ethService.isValidAddress(query)) {
-      const account = await this.accountService.findAccountByAddress(query)
+      const account = await this.accountService.findAccountByAddress(query.toLowerCase())
       if (account != null) {
 
         const isMiner = await this.accountService.findIsMiner(account.address)
@@ -44,6 +44,9 @@ export class SearchService {
 
     // Check Block, Uncle or Tx
     if (this.ethService.isValidHash(query)) {
+
+      query = query.toLowerCase() // Ensure query string is sanitized to lowercase before querying DB
+
       const block = await this.blockService.findByHash(query)
       if (block != null) {
         s.block = new BlockDto(block)

--- a/apps/api/src/shared/validation/parse-address.pipe.ts
+++ b/apps/api/src/shared/validation/parse-address.pipe.ts
@@ -12,6 +12,6 @@ export class ParseAddressPipe implements PipeTransform<string, string> {
     if (value.substring(0, 2) !== '0x') {
       value = `0x${value}`
     }
-    return value
+    return value.toLowerCase()
   }
 }

--- a/apps/api/src/shared/validation/parse-addresses.pipe.ts
+++ b/apps/api/src/shared/validation/parse-addresses.pipe.ts
@@ -14,6 +14,6 @@ export class ParseAddressesPipe implements PipeTransform<string[], string[]> {
         val = `0x${val}`
       }
     })
-    return value
+    return value.map(val => val.toLowerCase())
   }
 }

--- a/apps/api/src/shared/validation/parse-hash.pipe.ts
+++ b/apps/api/src/shared/validation/parse-hash.pipe.ts
@@ -12,6 +12,6 @@ export class ParseHashPipe implements PipeTransform<string, string> {
     if (value.substring(0, 2) !== '0x') {
       value = `0x${value}`
     }
-    return value
+    return value.toLowerCase()
   }
 }


### PR DESCRIPTION
Convert query strings to lowercase in ParseHashPipe, ParseAddressPipe and ParseAddressesPipe. Convert query strings to lowercase in SearchService when identified as valid hash or address.