### PR TITLE
Fix/block time column not found in entity error

### DIFF
--- a/apps/api/src/dao/block.service.ts
+++ b/apps/api/src/dao/block.service.ts
@@ -45,7 +45,7 @@ export class BlockService {
     if (blocks.length === 0) return null
 
     const avgBlockTime = blocks
-      .map(b => b.blockTime!!.blockTime)
+      .map(b => b.blockTime.blockTime)
       .reduceRight((memo, next) => memo.plus(next || 0), new BigNumber(0))
       .dividedBy(blocks.length)
 

--- a/apps/api/src/dao/block.service.ts
+++ b/apps/api/src/dao/block.service.ts
@@ -35,7 +35,7 @@ export class BlockService {
     // use up to the last 20 blocks which equates to about 5 mins at the current production rate
     const blocks = await this.blockHeaderRepository
       .find({
-        select: ['number', 'difficulty', 'blockTime'],
+        select: ['number', 'difficulty'],
         relations: ['blockTime'],
         order: { number: 'DESC' },
         take: 20,

--- a/apps/api/src/graphql/blocks/dto/block-header.dto.ts
+++ b/apps/api/src/graphql/blocks/dto/block-header.dto.ts
@@ -26,7 +26,7 @@ export class BlockHeaderDto implements BlockHeader {
 
   constructor(data: BlockHeaderEntity) {
     assignClean(this, data)
-    this.blockTime = data.blockTime!!.blockTime
+    this.blockTime = data.blockTime.blockTime || 0
   }
 
 }

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -319,14 +319,14 @@ export interface Metadata {
 
 export interface IQuery {
     accountByAddress(address: string): Account | Promise<Account>;
-    blockMetricsTransaction(offset?: number, limit?: number): BlockMetricsTransactionPage | Promise<BlockMetricsTransactionPage>;
-    blockMetricsTransactionFee(offset?: number, limit?: number): BlockMetricsTransactionFeePage | Promise<BlockMetricsTransactionFeePage>;
-    blockMetricsTimeseries(start: Date, end: Date, bucket: TimeBucket, field: BlockMetricField): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
     hashRate(): BigNumber | Promise<BigNumber>;
     blockSummaries(fromBlock?: BigNumber, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;
     blockSummariesByAuthor(author: string, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;
     blockByHash(hash: string): Block | Promise<Block>;
     blockByNumber(number: BigNumber): Block | Promise<Block>;
+    blockMetricsTransaction(offset?: number, limit?: number): BlockMetricsTransactionPage | Promise<BlockMetricsTransactionPage>;
+    blockMetricsTransactionFee(offset?: number, limit?: number): BlockMetricsTransactionFeePage | Promise<BlockMetricsTransactionFeePage>;
+    blockMetricsTimeseries(start: Date, end: Date, bucket: TimeBucket, field: BlockMetricField): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
     contractByAddress(address: string): Contract | Promise<Contract>;
     contractsCreatedBy(creator: string, offset?: number, limit?: number): ContractSummaryPage | Promise<ContractSummaryPage>;
     metadata(): Metadata | Promise<Metadata>;
@@ -390,11 +390,11 @@ export interface Search {
 }
 
 export interface ISubscription {
+    newBlock(): BlockSummary | Promise<BlockSummary>;
+    hashRate(): BigNumber | Promise<BigNumber>;
     newBlockMetric(): BlockMetric | Promise<BlockMetric>;
     newBlockMetricsTransaction(): BlockMetricsTransaction | Promise<BlockMetricsTransaction>;
     newBlockMetricsTransactionFee(): BlockMetricsTransactionFee | Promise<BlockMetricsTransactionFee>;
-    newBlock(): BlockSummary | Promise<BlockSummary>;
-    hashRate(): BigNumber | Promise<BigNumber>;
     isSyncing(): boolean | Promise<boolean>;
     newTransaction(): TransactionSummary | Promise<TransactionSummary>;
     newTransactions(): TransactionSummary[] | Promise<TransactionSummary[]>;

--- a/apps/api/src/orm/entities/block-header.entity.ts
+++ b/apps/api/src/orm/entities/block-header.entity.ts
@@ -2,7 +2,7 @@ import { BlockRewardEntity } from '@app/orm/entities/block-reward.entity'
 import { TransactionEntity } from '@app/orm/entities/transaction.entity'
 import { UncleEntity } from '@app/orm/entities/uncle.entity'
 import { assignClean } from '@app/shared/utils'
-import { Column, Entity, JoinColumn, OneToMany, PrimaryColumn } from 'typeorm'
+import { Column, Entity, JoinColumn, OneToMany, OneToOne, PrimaryColumn } from 'typeorm'
 import { BigNumber } from 'bignumber.js'
 import { BigNumberTransformer } from '../transformers/big-number.transformer'
 import { BlockTimeEntity } from '@app/orm/entities/block-time.entity'
@@ -71,12 +71,12 @@ export class BlockHeaderEntity {
   @Column({ type: 'int', readonly: true })
   size!: number
 
-  @OneToMany(type => BlockTimeEntity, bt => bt.blockHeader)
+  @OneToOne(type => BlockTimeEntity, bt => bt.blockHeader)
   @JoinColumn({
     name: 'number',
     referencedColumnName: 'number',
   })
-  blockTime?: BlockTimeEntity
+  blockTime!: BlockTimeEntity
 
   @OneToMany(type => TransactionEntity, tx => tx.blockHeader)
   @JoinColumn({

--- a/apps/api/src/orm/entities/block-time.entity.ts
+++ b/apps/api/src/orm/entities/block-time.entity.ts
@@ -1,8 +1,8 @@
-import {Column, Entity, JoinColumn, ManyToOne, PrimaryColumn} from 'typeorm'
-import {assignClean} from '@app/shared/utils';
-import {BigNumber} from 'bignumber.js';
-import {BigNumberTransformer} from '@app/orm/transformers/big-number.transformer';
-import {BlockHeaderEntity} from '@app/orm/entities/block-header.entity'
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm'
+import { assignClean } from '@app/shared/utils'
+import { BigNumber } from 'bignumber.js'
+import { BigNumberTransformer } from '@app/orm/transformers/big-number.transformer'
+import { BlockHeaderEntity } from '@app/orm/entities/block-header.entity'
 
 @Entity('canonical_block_time')
 export class BlockTimeEntity {
@@ -15,9 +15,9 @@ export class BlockTimeEntity {
   number!: BigNumber
 
   @Column({type: 'int', readonly: true})
-  blockTime!: number
+  blockTime?: number
 
-  @ManyToOne(type => BlockHeaderEntity, block => block.blockTime)
+  @OneToOne(type => BlockHeaderEntity, block => block.blockTime)
   @JoinColumn({
     name: 'number',
     referencedColumnName: 'number',

--- a/apps/api/src/orm/orm.module.ts
+++ b/apps/api/src/orm/orm.module.ts
@@ -33,7 +33,7 @@ import { DbConnection, SnakeCaseNamingStrategy } from '@app/orm/config'
         synchronize: false,
         namingStrategy: new SnakeCaseNamingStrategy(),
         entities: ['src/**/**.entity{.ts,.js}'],
-        logging: ['error', 'query'],
+        logging: ['error'],
         maxQueryExecutionTime: 1000,
         cache: {
           type: 'redis',


### PR DESCRIPTION
"hashRate" query was returning an error in the explorer: "blockTime column was not found in the BlockHeaderEntity entity"
- remove "hashRate" from select
- set BlockHeaderEntity <-> BlockTimeEntity relationship as one-to-one and required