### PR TITLE
Fix/ handle empty buffers

### DIFF
--- a/apps/api/src/graphql/scalars/buffer.scalar.ts
+++ b/apps/api/src/graphql/scalars/buffer.scalar.ts
@@ -9,7 +9,10 @@ export class BufferScalar {
   }
 
   serialize(value: Buffer) {
-    return value.toString('hex')
+    if (value && value instanceof Buffer && Array.from(value.entries()).length) {
+      return value.toString('hex')
+    }
+    return ''
   }
 
   parseLiteral(ast) {


### PR DESCRIPTION
Do not try to convert Buffers with no entries to string when serializing in BufferScalar