### PR TITLE
Fix/add type orm transformers for timestamp and bytea

### DIFF
--- a/apps/api/src/orm/entities/block-header.entity.ts
+++ b/apps/api/src/orm/entities/block-header.entity.ts
@@ -6,6 +6,7 @@ import { Column, Entity, JoinColumn, OneToMany, OneToOne, PrimaryColumn } from '
 import { BigNumber } from 'bignumber.js'
 import { BigNumberTransformer } from '../transformers/big-number.transformer'
 import { BlockTimeEntity } from '@app/orm/entities/block-time.entity'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_block_header')
 export class BlockHeaderEntity {
@@ -59,7 +60,7 @@ export class BlockHeaderEntity {
   @Column({ type: 'numeric', readonly: true, transformer: new BigNumberTransformer() })
   gasUsed!: BigNumber
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   timestamp!: Date
 
   @Column({ type: 'text', readonly: true })

--- a/apps/api/src/orm/entities/block-metric.entity.ts
+++ b/apps/api/src/orm/entities/block-metric.entity.ts
@@ -2,6 +2,7 @@ import {BigNumber} from 'bignumber.js'
 import {Column, Entity, PrimaryColumn} from 'typeorm'
 import {BigNumberTransformer} from '../transformers/big-number.transformer'
 import { assignClean } from '@app/shared/utils'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_block_metric')
 export class BlockMetricEntity {
@@ -13,7 +14,7 @@ export class BlockMetricEntity {
   @PrimaryColumn({type: 'numeric', readonly: true, transformer: new BigNumberTransformer()})
   number!: BigNumber
 
-  @PrimaryColumn({type: 'timestamp', readonly: true})
+  @PrimaryColumn({type: 'timestamp', readonly: true, transformer: new DateTransformer()})
   timestamp!: Date
 
   @Column({type: 'character', length: 66, unique: true, readonly: true})

--- a/apps/api/src/orm/entities/block-metrics-header.entity.ts
+++ b/apps/api/src/orm/entities/block-metrics-header.entity.ts
@@ -3,6 +3,7 @@ import { assignClean } from '@app/shared/utils'
 import { BigNumberTransformer } from '@app/orm/transformers/big-number.transformer'
 import { BigNumber } from 'bignumber.js'
 import { BlockTimeEntity } from '@app/orm/entities/block-time.entity'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_block_metrics_header')
 export class BlockMetricsHeaderEntity {
@@ -17,7 +18,7 @@ export class BlockMetricsHeaderEntity {
   @Column({ type: 'character', length: 66, unique: true, readonly: true })
   blockHash!: string
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   timestamp!: Date
 
   @Column({type: 'int', readonly: true})

--- a/apps/api/src/orm/entities/block-metrics-transaction-fee.entity.ts
+++ b/apps/api/src/orm/entities/block-metrics-transaction-fee.entity.ts
@@ -2,6 +2,7 @@ import { Column, Entity, PrimaryColumn } from 'typeorm'
 import { assignClean } from '@app/shared/utils'
 import { BigNumberTransformer } from '@app/orm/transformers/big-number.transformer'
 import { BigNumber } from 'bignumber.js'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_block_metrics_transaction_fee')
 export class BlockMetricsTransactionFeeEntity {
@@ -16,7 +17,7 @@ export class BlockMetricsTransactionFeeEntity {
   @Column({ type: 'character', length: 66, unique: true, readonly: true })
   blockHash!: string
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   timestamp!: Date
 
   @Column({ type: 'numeric', readonly: true, transformer: new BigNumberTransformer() })

--- a/apps/api/src/orm/entities/block-metrics-transaction-trace.entity.ts
+++ b/apps/api/src/orm/entities/block-metrics-transaction-trace.entity.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, PrimaryColumn } from 'typeorm'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_block_metrics_transaction_trace')
 export class BlockMetricsTransactionTraceEntity {
@@ -6,7 +7,7 @@ export class BlockMetricsTransactionTraceEntity {
   @PrimaryColumn({ type: 'character', length: 66, unique: true, readonly: true })
   blockHash!: string
 
-  @PrimaryColumn({ type: 'timestamp', readonly: true })
+  @PrimaryColumn({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   timestamp!: Date
 
   @Column({type: 'int', readonly: true})

--- a/apps/api/src/orm/entities/block-metrics-transaction.entity.ts
+++ b/apps/api/src/orm/entities/block-metrics-transaction.entity.ts
@@ -2,6 +2,7 @@ import { Column, Entity, PrimaryColumn } from 'typeorm'
 import { assignClean } from '@app/shared/utils'
 import { BigNumberTransformer } from '@app/orm/transformers/big-number.transformer'
 import { BigNumber } from 'bignumber.js'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_block_metrics_transaction')
 export class BlockMetricsTransactionEntity {
@@ -16,7 +17,7 @@ export class BlockMetricsTransactionEntity {
   @Column({ type: 'character', length: 66, unique: true, readonly: true })
   blockHash!: string
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   timestamp!: Date
 
   @Column({ type: 'numeric', readonly: true, transformer: new BigNumberTransformer() })

--- a/apps/api/src/orm/entities/contract.entity.ts
+++ b/apps/api/src/orm/entities/contract.entity.ts
@@ -7,6 +7,7 @@ import { BigNumberTransformer } from '@app/orm/transformers/big-number.transform
 import BigNumber from 'bignumber.js'
 import { TransactionEntity } from '@app/orm/entities/transaction.entity'
 import { TokenExchangeRateEntity } from '@app/orm/entities/token-exchange-rate.entity'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_contract')
 export class ContractEntity {
@@ -54,7 +55,7 @@ export class ContractEntity {
   @Column({ type: 'character', length: 64, readonly: true })
   traceCreatedAtTraceAddress?: string
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   traceCreatedAtTimestamp?: Date
 
   @Column({ type: 'character', length: 66, readonly: true })
@@ -75,10 +76,10 @@ export class ContractEntity {
   @Column({ type: 'character', length: 64, readonly: true })
   traceDestroyedAtTraceAddress?: string
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   traceDestroyedAtTimestamp?: Date
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   timestamp?: Date
 
   @OneToOne(type => Erc20MetadataEntity, metadata => metadata.contract)

--- a/apps/api/src/orm/entities/fungible-balance-transfer.entity.ts
+++ b/apps/api/src/orm/entities/fungible-balance-transfer.entity.ts
@@ -2,6 +2,7 @@ import { Column, Entity, PrimaryColumn } from 'typeorm'
 import { assignClean } from '@app/shared/utils'
 import { BigNumberTransformer } from '../transformers/big-number.transformer';
 import BigNumber from 'bignumber.js';
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_fungible_balance_transfer')
 export class FungibleBalanceTransferEntity {
@@ -49,7 +50,7 @@ export class FungibleBalanceTransferEntity {
   @Column({type: 'character varying', length: 64, readonly: true})
   traceLocationTraceAddress!: string
 
-  @Column({type: 'timestamp', readonly: true})
+  @Column({type: 'timestamp', readonly: true, transformer: new DateTransformer()})
   timestamp!: Date
 
 }

--- a/apps/api/src/orm/entities/internal-transfer.entity.ts
+++ b/apps/api/src/orm/entities/internal-transfer.entity.ts
@@ -2,6 +2,7 @@ import { Column, Entity, PrimaryColumn } from 'typeorm'
 import { assignClean } from '@app/shared/utils'
 import { BigNumberTransformer } from '@app/orm/transformers/big-number.transformer'
 import BigNumber from 'bignumber.js'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_internal_transfer')
 export class InternalTransferEntity {
@@ -49,7 +50,7 @@ export class InternalTransferEntity {
   @Column({type: 'character varying', length: 64, readonly: true})
   traceLocationTraceAddress!: string
 
-  @Column({type: 'timestamp', readonly: true})
+  @Column({type: 'timestamp', readonly: true, transformer: new DateTransformer()})
   timestamp!: Date
 
 }

--- a/apps/api/src/orm/entities/transaction-count.entity.ts
+++ b/apps/api/src/orm/entities/transaction-count.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, PrimaryColumn } from 'typeorm'
 import { assignClean } from '@app/shared/utils'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('transaction_count')
 export class TransactionCountEntity {
@@ -17,6 +18,6 @@ export class TransactionCountEntity {
   @Column({ type: 'integer', readonly: true })
   totalOut!: number
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   timestamp!: Date
 }

--- a/apps/api/src/orm/entities/transaction.entity.ts
+++ b/apps/api/src/orm/entities/transaction.entity.ts
@@ -7,6 +7,7 @@ import BigNumber from 'bignumber.js'
 import {BigNumberTransformer} from '@app/orm/transformers/big-number.transformer'
 import {ContractEntity} from '@app/orm/entities/contract.entity'
 import { DateTransformer } from '@app/orm/transformers/date.transformer'
+import { BufferTransformer } from '@app/orm/transformers/buffer.transformer'
 
 @Entity('canonical_transaction')
 export class TransactionEntity {
@@ -45,7 +46,7 @@ export class TransactionEntity {
   @Column({ type: 'numeric', readonly: true, transformer: new BigNumberTransformer() })
   gas!: BigNumber
 
-  @Column({ type: 'bytea', readonly: true })
+  @Column({ type: 'bytea', readonly: true, transformer: new BufferTransformer() })
   input?: Buffer
 
   @Column({ type: 'bigint', readonly: true })

--- a/apps/api/src/orm/entities/transaction.entity.ts
+++ b/apps/api/src/orm/entities/transaction.entity.ts
@@ -6,6 +6,7 @@ import {TransactionTraceEntity} from '@app/orm/entities/transaction-trace.entity
 import BigNumber from 'bignumber.js'
 import {BigNumberTransformer} from '@app/orm/transformers/big-number.transformer'
 import {ContractEntity} from '@app/orm/entities/contract.entity'
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_transaction')
 export class TransactionEntity {
@@ -56,7 +57,7 @@ export class TransactionEntity {
   @Column({ type: 'character', length: 78, readonly: true })
   s!: string
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   timestamp!: Date
 
   @Column({ type: 'character', length: 66, readonly: true })

--- a/apps/api/src/orm/entities/uncle.entity.ts
+++ b/apps/api/src/orm/entities/uncle.entity.ts
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js';
 import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Column } from 'typeorm/decorator/columns/Column';
 import { BigNumberTransformer } from '../transformers/big-number.transformer';
+import { DateTransformer } from '@app/orm/transformers/date.transformer'
 
 @Entity('canonical_uncle')
 export class UncleEntity {
@@ -69,7 +70,7 @@ export class UncleEntity {
   @Column({ type: 'numeric', readonly: true, transformer: new BigNumberTransformer() })
   gasUsed!: BigNumber
 
-  @Column({ type: 'timestamp', readonly: true })
+  @Column({ type: 'timestamp', readonly: true, transformer: new DateTransformer() })
   timestamp!: Date
 
   @Column({ type: 'bigint', readonly: true })

--- a/apps/api/src/orm/transformers/buffer.transformer.ts
+++ b/apps/api/src/orm/transformers/buffer.transformer.ts
@@ -1,0 +1,56 @@
+import { FindOperator, FindOperatorType, ValueTransformer } from 'typeorm'
+
+export class BufferTransformer implements ValueTransformer {
+
+  to(value?: Buffer | FindOperator<Buffer | Buffer[]>) {
+
+    if (!value) {
+
+      return undefined
+
+    } else if (value instanceof Buffer) {
+
+      return value.toString('hex')
+
+    } else if (value instanceof FindOperator) {
+
+      // Buffer is being used as part of a query e.g. In(...), LessThanOrEqual(...)
+
+      const operator = value
+
+      let newValue
+
+      if (value.multipleParameters) {
+
+        const arrayValue = (operator.value as Buffer[]) || []
+        newValue = arrayValue.map(v => v.toString('hex'))
+
+      } else {
+        newValue = value.value ? (value.value as Buffer).toString('hex') : undefined
+      }
+
+      // we need this naked reference so we can access the private _type property
+      const operatorNaked = value as any
+
+      return new FindOperator(
+        operatorNaked._type as FindOperatorType,
+        newValue,
+        operator.useParameter,
+        operator.multipleParameters,
+      )
+
+    }
+  }
+
+  from(value?: any): Buffer | undefined {
+    if (!value) return undefined
+    if (value instanceof Buffer) {
+      return value
+    }
+    if (typeof value === 'string') {
+      return Buffer.from(value, 'hex')
+    }
+    return Buffer.from(value)
+  }
+
+}

--- a/apps/api/src/orm/transformers/date.transformer.ts
+++ b/apps/api/src/orm/transformers/date.transformer.ts
@@ -1,0 +1,53 @@
+import { FindOperator, FindOperatorType, ValueTransformer } from 'typeorm'
+
+export class DateTransformer implements ValueTransformer {
+
+  to(value?: Date | FindOperator<Date | Date[]>) {
+
+    if (!value) {
+
+      return undefined
+
+    } else if (value instanceof Date) {
+
+      return value.toString()
+
+    } else if (value instanceof FindOperator) {
+
+      // date is being used as part of a query e.g. In(...), LessThanOrEqual(...)
+
+      const operator = value
+
+      let newValue
+
+      if (value.multipleParameters) {
+
+        const arrayValue = (operator.value as Date[]) || []
+        newValue = arrayValue.map(v => v.toString())
+
+      } else {
+        newValue = value.value ? (value.value as Date).toString() : undefined
+      }
+
+      // we need this naked reference so we can access the private _type property
+      const operatorNaked = value as any
+
+      return new FindOperator(
+        operatorNaked._type as FindOperatorType,
+        newValue,
+        operator.useParameter,
+        operator.multipleParameters,
+      )
+
+    }
+  }
+
+  from(value?: any): Date | undefined {
+    if (!value) return undefined
+    if (value instanceof Date) {
+      return value
+    }
+    return new Date(value)
+  }
+
+}


### PR DESCRIPTION
This is in response to reported issue in Ropsten with timestamp fields sometimes causing the error: 'value.getTime() is not a function' and bytea fields sometimes returning '[object Object]' after conversion to string. Both errors are difficult to replicate locally. The only way to confirm if this fix is successful is to test in a fully-synced environment.

Solution proposed in this PR:
- use custom ValueTransformers to handle converting values from DB into the types we require, rather than relying on typeORM to do the conversion.