### PR TITLE
Fix/token details list num transfers

### DIFF
--- a/apps/api/src/dao/transfer.service.ts
+++ b/apps/api/src/dao/transfer.service.ts
@@ -68,6 +68,17 @@ export class TransferService {
 
   }
 
+  async findTotalTokenTransfersByContractAddressForHolder(contractAddress: string, holderAddress: string): Promise<BigNumber> {
+
+    return new BigNumber(await this.deltaRepository.createQueryBuilder('d')
+      .where('d.delta_type = :deltaType')
+      .andWhere('d.address = :holderAddress')
+      .andWhere('d.contract_address = :contractAddress')
+      .setParameters({ deltaType: 'TOKEN_TRANSFER', holderAddress, contractAddress })
+      .getCount())
+
+  }
+
   async findInternalTransactionsByAddress(address: string, offset: number = 0, limit: number = 10): Promise<[InternalTransferEntity[], number]> {
 
     return this.entityManager.transaction(

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -348,6 +348,7 @@ export interface IQuery {
     tokenBalancesByContractAddressForHolder(contractAddress: string, holderAddress: string, timestampFrom?: number, timestampTo?: number): BalancesPage | Promise<BalancesPage>;
     tokenTransfersByContractAddress(contractAddress: string, offset?: number, limit?: number): TransferPage | Promise<TransferPage>;
     tokenTransfersByContractAddressForHolder(contractAddress: string, holderAddress: string, filter?: FilterEnum, offset?: number, limit?: number): TransferPage | Promise<TransferPage>;
+    totalTokenTransfersByContractAddressForHolder(contractAddress: string, holderAddress: string): BigNumber | Promise<BigNumber>;
     transactionSummaries(fromBlock?: BigNumber, offset?: number, limit?: number): TransactionSummaryPage | Promise<TransactionSummaryPage>;
     transactionSummariesForBlockNumber(number: BigNumber, offset?: number, limit?: number): TransactionSummaryPage | Promise<TransactionSummaryPage>;
     transactionSummariesForBlockHash(hash: string, offset?: number, limit?: number): TransactionSummaryPage | Promise<TransactionSummaryPage>;

--- a/apps/api/src/graphql/transfers/transfer.graphql
+++ b/apps/api/src/graphql/transfers/transfer.graphql
@@ -5,6 +5,8 @@ type Query {
 
   tokenTransfersByContractAddress(contractAddress: String!, offset: Int = 0, limit: Int = 20): TransferPage!
   tokenTransfersByContractAddressForHolder(contractAddress: String!, holderAddress: String!, filter: FilterEnum = all, offset: Int = 0, limit: Int = 20): TransferPage!
+
+  totalTokenTransfersByContractAddressForHolder(contractAddress: String!, holderAddress: String!): BigNumber!
 }
 
 type TransferPage {

--- a/apps/api/src/graphql/transfers/transfer.resolvers.ts
+++ b/apps/api/src/graphql/transfers/transfer.resolvers.ts
@@ -7,6 +7,7 @@ import { BalancesPageDto } from '@app/graphql/transfers/dto/balances-page.dto'
 import { UseInterceptors } from '@nestjs/common'
 import { SyncingInterceptor } from '@app/shared/interceptors/syncing-interceptor'
 import { InternalTransferPageDto } from '@app/graphql/transfers/dto/internal-transfer-page.dto'
+import BigNumber from 'bignumber.js'
 
 @Resolver('Transfer')
 @UseInterceptors(SyncingInterceptor)
@@ -40,6 +41,14 @@ export class TransferResolvers {
       items: result[0],
       totalCount: result[1],
     })
+  }
+
+  @Query()
+  async totalTokenTransfersByContractAddressForHolder(
+    @Args('contractAddress', ParseAddressPipe) contractAddress: string,
+    @Args('holderAddress', ParseAddressPipe) holderAddress: string,
+  ): Promise<BigNumber> {
+    return this.transferService.findTotalTokenTransfersByContractAddressForHolder(contractAddress, holderAddress)
   }
 
   @Query()

--- a/apps/explorer/src/core/api/apollo/extensions/token-holder.ext.ts
+++ b/apps/explorer/src/core/api/apollo/extensions/token-holder.ext.ts
@@ -5,13 +5,19 @@ export class TokenHolderExt implements TokenHolder {
   __typename!: 'TokenHolder'
   address: string
   balance: any
+  totalTransfers: any
 
-  constructor(proto: TokenHolder) {
+  constructor(proto: TokenHolder, totalTransfers?: any) {
     this.address = proto.address
     this.balance = proto.balance
+    this.totalTransfers = totalTransfers
   }
 
   get balanceBN(): BigNumber {
     return new BigNumber(this.balance || 0)
+  }
+
+  get totalTransfersBN(): BigNumber | undefined {
+    return this.totalTransfers ? new BigNumber(this.totalTransfers) : undefined
   }
 }

--- a/apps/explorer/src/core/api/apollo/types/tokenHolderDetails.ts
+++ b/apps/explorer/src/core/api/apollo/types/tokenHolderDetails.ts
@@ -53,6 +53,7 @@ export interface tokenHolderDetails_tokenDetails {
 export interface tokenHolderDetails {
   tokenHolder: tokenHolderDetails_tokenHolder | null;
   tokenDetails: tokenHolderDetails_tokenDetails | null;
+  totalTransfers: any;
 }
 
 export interface tokenHolderDetailsVariables {

--- a/apps/explorer/src/modules/tokens/components/TokenDetailsList.vue
+++ b/apps/explorer/src/modules/tokens/components/TokenDetailsList.vue
@@ -281,7 +281,8 @@ export default class TokenDetailsList extends Mixins(StringConcatMixin) {
   get holderTransfersDetail(): Detail {
     // TODO get transfers info and add to Detail object
     return {
-      title: this.$t('token.transfers')
+      title: this.$t('token.transfers'),
+      detail: !this.isLoading && this.holderDetails && this.holderDetails.totalTransfersBN ? this.holderDetails.totalTransfersBN.toString() : undefined
     }
   }
 

--- a/apps/explorer/src/modules/tokens/components/TokenDetailsList.vue
+++ b/apps/explorer/src/modules/tokens/components/TokenDetailsList.vue
@@ -279,7 +279,6 @@ export default class TokenDetailsList extends Mixins(StringConcatMixin) {
   }
 
   get holderTransfersDetail(): Detail {
-    // TODO get transfers info and add to Detail object
     return {
       title: this.$t('token.transfers'),
       detail: !this.isLoading && this.holderDetails && this.holderDetails.totalTransfersBN ? this.holderDetails.totalTransfersBN.toString() : undefined

--- a/apps/explorer/src/modules/tokens/pages/PageDetailsToken.vue
+++ b/apps/explorer/src/modules/tokens/pages/PageDetailsToken.vue
@@ -92,9 +92,9 @@ const MAX_ITEMS = 10
         return { address: this.addressRef, holderAddress: this.holderAddress }
       },
 
-      update({ tokenDetails, tokenHolder }) {
+      update({ tokenDetails, tokenHolder, totalTransfers }) {
         if (tokenHolder) {
-          this.holderDetails = new TokenHolderExt(tokenHolder)
+          this.holderDetails = new TokenHolderExt(tokenHolder, totalTransfers)
         }
 
         if (tokenDetails) {

--- a/apps/explorer/src/modules/tokens/tokens.graphql
+++ b/apps/explorer/src/modules/tokens/tokens.graphql
@@ -87,4 +87,5 @@ query tokenHolderDetails($address: String! $holderAddress: String!) {
   tokenDetails: tokenDetailByAddress(address: $address) {
     ...TokenDetail
   }
+  totalTransfers: totalTokenTransfersByContractAddressForHolder(contractAddress: $address, holderAddress: $holderAddress)
 }


### PR DESCRIPTION
Adds graphQL query for retrieving the total number of transfers for a given holder address and contract address to display in token detail page holder view.