### PR TITLE
Fix/add minimum to timeseries queries

### DIFF
--- a/apps/api/src/dao/block-metrics.service.ts
+++ b/apps/api/src/dao/block-metrics.service.ts
@@ -151,13 +151,13 @@ export class BlockMetricsService {
     bucket: TimeBucket,
     field: BlockMetricField,
     start?: Date,
-    end?: Date,
+    end: Date = new Date('2000-01-01T00:00:00.000Z'),
   ): Promise<AggregateBlockMetric[]> {
 
     // If start or end is set, round to nearest minute in order to take advantage of caching similar queries
     // Start is set to end of minute as it is later in time, and vice versa, to be inclusive of time range
     start = start ? moment(start).endOf('minute').toDate() : undefined
-    end = end ? moment(end).startOf('minute').toDate() : undefined
+    end = moment(end).startOf('minute').toDate()
 
     const datapoints = this.estimateDatapoints(start, end, bucket)
 
@@ -251,14 +251,10 @@ export class BlockMetricsService {
 
     // Set where clause if start and/or end params are set
 
-    if (start && end) {
+    if (start) {
       queryBuilder.where('bm.timestamp between :end and :start', {start, end})
-    } else if (start) {
-      queryBuilder.where('bm.timestamp < :start', {start})
-    } else if (end) {
-      queryBuilder.where('bm.timestamp > :end', {end})
     } else {
-      queryBuilder.where('bm.timestamp IS NOT NULL') // Ensure items without timestamp are ignored
+      queryBuilder.where('bm.timestamp > :end', {end})
     }
 
     const items = await queryBuilder

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -320,14 +320,14 @@ export interface Metadata {
 
 export interface IQuery {
     accountByAddress(address: string): Account | Promise<Account>;
+    blockMetricsTransaction(offset?: number, limit?: number): BlockMetricsTransactionPage | Promise<BlockMetricsTransactionPage>;
+    blockMetricsTransactionFee(offset?: number, limit?: number): BlockMetricsTransactionFeePage | Promise<BlockMetricsTransactionFeePage>;
+    blockMetricsTimeseries(bucket: TimeBucket, field: BlockMetricField, start?: Date, end?: Date): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
     hashRate(): BigNumber | Promise<BigNumber>;
     blockSummaries(fromBlock?: BigNumber, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;
     blockSummariesByAuthor(author: string, offset?: number, limit?: number): BlockSummaryPage | Promise<BlockSummaryPage>;
     blockByHash(hash: string): Block | Promise<Block>;
     blockByNumber(number: BigNumber): Block | Promise<Block>;
-    blockMetricsTransaction(offset?: number, limit?: number): BlockMetricsTransactionPage | Promise<BlockMetricsTransactionPage>;
-    blockMetricsTransactionFee(offset?: number, limit?: number): BlockMetricsTransactionFeePage | Promise<BlockMetricsTransactionFeePage>;
-    blockMetricsTimeseries(bucket: TimeBucket, field: BlockMetricField, start?: Date, end?: Date): AggregateBlockMetric[] | Promise<AggregateBlockMetric[]>;
     contractByAddress(address: string): Contract | Promise<Contract>;
     contractsCreatedBy(creator: string, offset?: number, limit?: number): ContractSummaryPage | Promise<ContractSummaryPage>;
     metadata(): Metadata | Promise<Metadata>;
@@ -392,11 +392,11 @@ export interface Search {
 }
 
 export interface ISubscription {
-    newBlock(): BlockSummary | Promise<BlockSummary>;
-    hashRate(): BigNumber | Promise<BigNumber>;
     newBlockMetric(): BlockMetric | Promise<BlockMetric>;
     newBlockMetricsTransaction(): BlockMetricsTransaction | Promise<BlockMetricsTransaction>;
     newBlockMetricsTransactionFee(): BlockMetricsTransactionFee | Promise<BlockMetricsTransactionFee>;
+    newBlock(): BlockSummary | Promise<BlockSummary>;
+    hashRate(): BigNumber | Promise<BigNumber>;
     isSyncing(): boolean | Promise<boolean>;
     newTransaction(): TransactionSummary | Promise<TransactionSummary>;
     newTransactions(): TransactionSummary[] | Promise<TransactionSummary[]>;


### PR DESCRIPTION
Don't retrieve BlockMetrics timeseries data for genesis block.