### PR TITLE
feat: added balanceTransfersByHolderAddress query

### DIFF
--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -346,6 +346,7 @@ export interface IQuery {
     tokenTransfersByContractAddressesForHolder(contractAddresses: string[], holderAddress: string, filter?: FilterEnum, limit?: number, page?: number, timestampFrom?: number, timestampTo?: number): TransferPage | Promise<TransferPage>;
     internalTransactionsByAddress(address: string, offset?: number, limit?: number): TransferPage | Promise<TransferPage>;
     tokenBalancesByContractAddressForHolder(contractAddress: string, holderAddress: string, timestampFrom?: number, timestampTo?: number): BalancesPage | Promise<BalancesPage>;
+    balanceTransfersByHolderAddress(holderAddress: string, contractAddresses?: string[], limit?: number, page?: number, timestampFrom?: number, timestampTo?: number): TransferPage | Promise<TransferPage>;
     tokenTransfersByContractAddress(contractAddress: string, offset?: number, limit?: number): TransferPage | Promise<TransferPage>;
     tokenTransfersByContractAddressForHolder(contractAddress: string, holderAddress: string, filter?: FilterEnum, offset?: number, limit?: number): TransferPage | Promise<TransferPage>;
     totalTokenTransfersByContractAddressForHolder(contractAddress: string, holderAddress: string): BigNumber | Promise<BigNumber>;

--- a/apps/api/src/graphql/transfers/transfer.graphql
+++ b/apps/api/src/graphql/transfers/transfer.graphql
@@ -3,6 +3,8 @@ type Query {
   internalTransactionsByAddress(address: String!, offset: Int = 0, limit: Int = 20): TransferPage!
   tokenBalancesByContractAddressForHolder(contractAddress: String!, holderAddress: String!, timestampFrom: Int = 0, timestampTo: Int = 0): BalancesPage
 
+  balanceTransfersByHolderAddress(holderAddress: String!, contractAddresses: [String], limit: Int = 20, page: Int = 0, timestampFrom: Int = 0, timestampTo: Int = 0): TransferPage
+
   tokenTransfersByContractAddress(contractAddress: String!, offset: Int = 0, limit: Int = 20): TransferPage!
   tokenTransfersByContractAddressForHolder(contractAddress: String!, holderAddress: String!, filter: FilterEnum = all, offset: Int = 0, limit: Int = 20): TransferPage!
 

--- a/apps/api/src/graphql/transfers/transfer.resolvers.ts
+++ b/apps/api/src/graphql/transfers/transfer.resolvers.ts
@@ -92,4 +92,21 @@ export class TransferResolvers {
       totalCount: result[1],
     })
   }
+
+  @Query()
+  async balanceTransfersByHolderAddress(
+    @Args('holderAddress', ParseAddressPipe) holderAddress: string,
+    @Args({name: 'contractAddresses', type: () => [String]}, ParseAddressesPipe) contractAddresses: string[],
+    @Args('limit') limit: number,
+    @Args('page') page: number,
+    @Args('timestampFrom') timestampFrom: number,
+    @Args('timestampTo') timestampTo: number,
+  ): Promise<TransferPageDto> {
+    const result = await this.transferService
+      .findBalanceTransfersByHolderAddress(holderAddress, contractAddresses, limit, page, timestampFrom, timestampTo)
+    return new TransferPageDto({
+      items: result[0],
+      totalCount: result[1],
+    })
+  }
 }

--- a/apps/api/src/shared/validation/parse-addresses.pipe.ts
+++ b/apps/api/src/shared/validation/parse-addresses.pipe.ts
@@ -5,7 +5,7 @@ import { EthService } from '@app/shared/eth.service'
 export class ParseAddressesPipe implements PipeTransform<string[], string[]> {
   constructor(private readonly ethService: EthService) {}
 
-  transform(value: string[], metadata: ArgumentMetadata): string[] {
+  transform(value: string[] = [], metadata: ArgumentMetadata): string[] {
     value.forEach(val => {
       if (!this.ethService.isValidAddress(val)) {
         throw new BadRequestException('Invalid address hash')


### PR DESCRIPTION
Asana Cross-reference: https://app.asana.com/0/1126531526810286/1133818918608561

This PR attempts to add a query for the functionality discussed earlier today 7/31:

Currently, there only exists a query that retrieves TOKEN_TRANSFERS from the fungible_balance_transfer entity. MEW Mobile requires the ability to get the "transactions" (fungible_balance_transfers) for both ETH and tokens for a given holderAddress (and possible array of tokens/ETH-- e.g. limited to [ETH and GOT] ).

The new query, **balanceTransfersByHolderAddress**, attempts to add this functionality.

There are some weird caveats: since it is in the spec that a user can provide a list of "contractAddresses" to get the transaction history for, from a specific holder address, but ETH does not have a contractAddress, I made the query work as follows: 

If the contractAddresses parameter array includes the "holderAddress" parameter, then the query will also include ETH transfers, rather than just token transfers.