### PR TITLE
Fix/include internal txs with zero value in query results

### DIFF
--- a/apps/api/src/dao/account.service.ts
+++ b/apps/api/src/dao/account.service.ts
@@ -56,7 +56,7 @@ export class AccountService {
 
     const transfer = await this.internalTransferRepository.findOne({
       select: ['id'],
-      where: { address, amount: Not(new BigNumber(0)) },
+      where: { address },
       cache: true,
     })
 

--- a/apps/api/src/dao/transfer.service.ts
+++ b/apps/api/src/dao/transfer.service.ts
@@ -85,11 +85,10 @@ export class TransferService {
       'READ COMMITTED',
       async (txn): Promise<[InternalTransferEntity[], number]> => {
 
-        const count = await txn.count(InternalTransferEntity, { where: { address, amount: Not(new BigNumber(0)) }, cache: true })
+        const count = await txn.count(InternalTransferEntity, { where: { address }, cache: true })
 
         const items = await txn.createQueryBuilder(InternalTransferEntity, 'it')
           .where('it.address = :address', { address })
-          .andWhere('it.amount != 0')
           .orderBy('trace_location_block_number', 'DESC')
           .addOrderBy('trace_location_transaction_index', 'DESC')
           .addOrderBy('trace_location_trace_address', 'DESC')

--- a/apps/api/src/graphql/transfers/dto/internal-transfer.dto.ts
+++ b/apps/api/src/graphql/transfers/dto/internal-transfer.dto.ts
@@ -19,14 +19,9 @@ export class InternalTransferDto implements Transfer {
   constructor(data: InternalTransferEntity) {
     assignClean(this, data)
 
-    // Use "-" symbol to determine "to" and "from" from "address" and "counterpartAddress" fields
-    if (this.amount > 0) { // Transfer is incoming
-      this.to = data.address
-      this.from = data.counterpartAddress
-    }
-    if (this.amount < 0) { // Transfer is outgoing
-      this.to = data.counterpartAddress!
-      this.from = data.address
-    }
+    // Assign "to" and "from" depending on "isReceiving" flag
+    this.to = data.isReceiving ? data.address : data.counterpartAddress!
+    this.from = data.isReceiving ? data.counterpartAddress : data.address
+
   }
 }

--- a/apps/api/src/orm/entities/internal-transfer.entity.ts
+++ b/apps/api/src/orm/entities/internal-transfer.entity.ts
@@ -44,4 +44,7 @@ export class InternalTransferEntity {
   @Column({type: 'timestamp', readonly: true, transformer: new DateTransformer()})
   timestamp!: Date
 
+  @Column({type: 'boolean', readonly: true})
+  isReceiving!: boolean
+
 }


### PR DESCRIPTION
Ensures internal transfers of 0 amount are included in internalTransfer queries. Uses new column "is_receiving" to assign "to" and "from" fields in dto constructor.