### PR TITLE
Fix/last update stat on load

### DIFF
--- a/apps/explorer/src/core/components/ui/AppCardStatsGroup.vue
+++ b/apps/explorer/src/core/components/ui/AppCardStatsGroup.vue
@@ -191,7 +191,6 @@ export default class AppInfoCardGroup extends Vue {
     */
 
   startCount(): void {
-
     this.secondsInterval = window.setInterval(() => {
       if (this.blockSummary) {
         const lastTimestamp = this.lastReceivedAt || new Date()

--- a/apps/explorer/src/core/components/ui/AppCardStatsGroup.vue
+++ b/apps/explorer/src/core/components/ui/AppCardStatsGroup.vue
@@ -67,7 +67,11 @@ enum HashUnitLabel {
 
       update({ blockSummaries }) {
         if (blockSummaries && blockSummaries.items.length) {
-          this.lastReceivedAt = new Date()
+          // If this is the first blockSummary received (i.e. page has just loaded), initialize "seconds" as seconds since timestamp of this block
+          if (!this.blockSummary) {
+            this.lastReceivedAt = new Date(blockSummaries.items[0].timestamp)
+            this.seconds = Math.ceil((new Date().getTime() - blockSummaries.items[0].timestamp) / 1000)
+          }
           return new BlockSummaryPageExt_items(blockSummaries.items[0])
         }
         return null
@@ -78,7 +82,7 @@ enum HashUnitLabel {
 
         updateQuery(previousResult, { subscriptionData }) {
           const { newBlock } = subscriptionData.data
-          this.lastReceivedAt = new Date()
+          this.lastReceivedAt = new Date() // Update "last update" time to moment client received the update (not to the block timestamp)
           return {
             ...previousResult,
             blockSummaries: {
@@ -187,6 +191,7 @@ export default class AppInfoCardGroup extends Vue {
     */
 
   startCount(): void {
+
     this.secondsInterval = window.setInterval(() => {
       if (this.blockSummary) {
         const lastTimestamp = this.lastReceivedAt || new Date()

--- a/apps/explorer/src/core/components/ui/AppCardStatsGroup.vue
+++ b/apps/explorer/src/core/components/ui/AppCardStatsGroup.vue
@@ -41,7 +41,14 @@
 
 <script lang="ts">
 import AppInfoCard from '@app/core/components/ui/AppInfoCard.vue'
-import { latestBlockStats, newBlockStats, latestHashRate, newHashRate, lastBlockReceivedQuery, updateLastBlockReceivedMutation } from '@app/core/components/ui/stats.graphql'
+import {
+  latestBlockStats,
+  newBlockStats,
+  latestHashRate,
+  newHashRate,
+  lastBlockReceivedQuery,
+  updateLastBlockReceivedMutation
+} from '@app/core/components/ui/stats.graphql'
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import BigNumber from 'bignumber.js'
 import { Subscription } from 'rxjs'
@@ -204,10 +211,10 @@ export default class AppInfoCardGroup extends Vue {
   }
 
   updateLastBlockReceived(timestamp): void {
-      this.$apollo.mutate({
-          mutation: updateLastBlockReceivedMutation,
-          variables: { timestamp }
-      })
+    this.$apollo.mutate({
+      mutation: updateLastBlockReceivedMutation,
+      variables: { timestamp }
+    })
   }
 
   calculateHashValueAndLabel(value?: BigNumber): [BigNumber | undefined, HashUnitLabel] {

--- a/apps/explorer/src/core/components/ui/stats.graphql
+++ b/apps/explorer/src/core/components/ui/stats.graphql
@@ -31,3 +31,22 @@ query latestHashRate {
 subscription newHashRate {
   hashRate
 }
+
+type BlockReceived {
+  timestamp: BigNumber!
+}
+
+type Mutation {
+  updateLastBlockReceived(timestamp: BigNumber!): Boolean
+}
+
+type Query {
+  lastBlockReceived: BigNumber
+}
+
+mutation updateLastBlockReceivedMutation($timestamp: BigNumber) {
+  updateLastBlockReceived(timestamp: $timestamp) @client
+}
+query lastBlockReceivedQuery {
+  lastBlockReceived @client
+}

--- a/apps/explorer/src/main.ts
+++ b/apps/explorer/src/main.ts
@@ -14,6 +14,7 @@ import { getMainDefinition } from 'apollo-utilities'
 import Vue from 'vue'
 import VueApollo from 'vue-apollo'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
+import { lastBlockReceivedQuery } from '@app/core/components/ui/stats.graphql'
 
 /*
   ===================================================================================
@@ -46,11 +47,30 @@ const link = split(
   httpLink
 )
 
+const cache = new InMemoryCache();
+
+const resolvers = {
+  Mutation: {
+    updateLastBlockReceived: (_, { timestamp }, {cache}) => {
+      const data = { lastBlockReceived: timestamp }
+      cache.writeQuery({query: lastBlockReceivedQuery, data})
+      return timestamp
+    },
+  }
+}
+
 const apolloClient = new ApolloClient({
   link: link,
-  cache: new InMemoryCache(),
-  connectToDevTools: process.env.NODE_ENV === 'development'
+  cache,
+  connectToDevTools: process.env.NODE_ENV === 'development',
+  resolvers
 })
+
+cache.writeData({
+  data: {
+    lastBlockReceived: null
+  },
+});
 
 const apolloProvider = new VueApollo({
   defaultClient: apolloClient

--- a/apps/explorer/src/main.ts
+++ b/apps/explorer/src/main.ts
@@ -47,15 +47,15 @@ const link = split(
   httpLink
 )
 
-const cache = new InMemoryCache();
+const cache = new InMemoryCache()
 
 const resolvers = {
   Mutation: {
-    updateLastBlockReceived: (_, { timestamp }, {cache}) => {
+    updateLastBlockReceived: (_, { timestamp }, { cache }) => {
       const data = { lastBlockReceived: timestamp }
-      cache.writeQuery({query: lastBlockReceivedQuery, data})
+      cache.writeQuery({ query: lastBlockReceivedQuery, data })
       return timestamp
-    },
+    }
   }
 }
 
@@ -69,8 +69,8 @@ const apolloClient = new ApolloClient({
 cache.writeData({
   data: {
     lastBlockReceived: null
-  },
-});
+  }
+})
 
 const apolloProvider = new VueApollo({
   defaultClient: apolloClient


### PR DESCRIPTION
Current behavior resets "last update" stat to 0 when a page loads, which is very misleading if the most recent block was actually received some time ago, and completely changes when navigating between different pages. This PR ensures "last update" is initialized according to the timestamp of the last block received, then relies on time client receives updates to calculate it after initialization.

The downside of this is that the "last update" stat can seem to jump between homepage and blocks page. For example on homepage a new block was received, "last update" time is calculated from when it was received by client. Then navigating to blocks page, the time is calculated from the timestamp of that block which could be ~6 seconds different, causing the time to "jump" by ~6 seconds.