### PR TITLE
fix: Blocks page "fromBlock" param 

### DIFF
--- a/apps/api/src/dao/block.service.ts
+++ b/apps/api/src/dao/block.service.ts
@@ -73,7 +73,7 @@ export class BlockService {
             .leftJoinAndSelect('b.rewards', 'br')
 
           if (fromBlock) {
-            queryBuilder.where('b.number <= :fromBlock', { fromBlock })
+            queryBuilder.where('b.number <= :fromBlock', { fromBlock: fromBlock.toNumber() })
           }
 
           const headersWithRewards = await queryBuilder


### PR DESCRIPTION
Convert "fromBlock" to number before passing to query builder in blockServive.findSummaries()