### PR TITLE
fix: Handle case where valid hash matches no txs in tx query

### DIFF
--- a/apps/api/src/dao/tx.service.ts
+++ b/apps/api/src/dao/tx.service.ts
@@ -60,6 +60,9 @@ export class TxService {
       relations: ['receipt'],
       cache: true,
     })
+    if (!txs.length) { // User may be searching by hash which does not exist as a tx
+      return []
+    }
     return this.findAndMapTraces(txs)
   }
 


### PR DESCRIPTION
Return empty array before trying to retrieve traces etc if no transaction is found matching a provided "valid" hash in tx query.