### PR TITLE
fix: Construct TokenTableHolders links correctly

### DIFF
--- a/apps/api/src/orm/orm.module.ts
+++ b/apps/api/src/orm/orm.module.ts
@@ -56,7 +56,7 @@ export class OrmModule {
     @InjectConnection(DbConnection.Metrics)
     private readonly metricsConnection: Connection,
     @Inject('winston')
-    private readonly logger: Logger
+    private readonly logger: Logger,
   ) {
 
     // we set statement timeout on all connections to max 20 seconds

--- a/apps/explorer/src/modules/tokens/components/TokenTableHolders.vue
+++ b/apps/explorer/src/modules/tokens/components/TokenTableHolders.vue
@@ -52,7 +52,7 @@
           <v-card-text class="text-xs-center secondary--text">{{ $t('message.token.no-holders') }}</v-card-text>
         </v-card>
         <div v-else v-for="(holder, i) in holders" :key="i">
-          <token-table-holders-row :holder="holder" :decimals="decimals" :total-supply="totalSupply" />
+          <token-table-holders-row :holder="holder" :token-address="addressRef" :decimals="decimals" :total-supply="totalSupply" />
         </div>
       </div>
     </div>

--- a/apps/explorer/src/modules/tokens/components/TokenTableHoldersRow.vue
+++ b/apps/explorer/src/modules/tokens/components/TokenTableHoldersRow.vue
@@ -80,6 +80,7 @@ export default class TokenTableHoldersRow extends Vue {
   */
 
   @Prop(TokenHolderPageExt_items) holder!: TokenHolderPageExt_items
+  @Prop(String) tokenAddress!: string
   @Prop(BN) totalSupply?: BN
   @Prop(Number) decimals?: number
   /*
@@ -95,7 +96,7 @@ export default class TokenTableHoldersRow extends Vue {
    * @return {String}        [description]
    */
   holderAddress(holder) {
-    return `/token/${this.holder.address}?holder=${this.holder.address}`
+    return `/token/${this.tokenAddress}?holder=${this.holder.address}`
   }
 
   /**


### PR DESCRIPTION
TokenTableHoldersRow link goes to: token/:tokenAddress?holder=:holderAddress