### PR TITLE
Fix/update live charts queries when mounted

### DIFF
--- a/apps/explorer/src/modules/charts/components/live/ChartLiveTxFees.vue
+++ b/apps/explorer/src/modules/charts/components/live/ChartLiveTxFees.vue
@@ -182,6 +182,12 @@ export default class ChartLiveTxFees extends Vue {
     })
   }
 
+  mounted() {
+    // Ensure queries are refetched each time the component is mounted to keep data updated
+    this.$apollo.queries.avgGasPrice.refetch()
+    this.$apollo.queries.avgTxFees.refetch()
+  }
+
   destroyed() {
     if (this.connectedSubscription) {
       this.connectedSubscription.unsubscribe()

--- a/apps/explorer/src/modules/charts/components/live/ChartLiveTxs.vue
+++ b/apps/explorer/src/modules/charts/components/live/ChartLiveTxs.vue
@@ -120,6 +120,11 @@ export default class ChartLiveTxs extends Vue {
     })
   }
 
+  mounted() {
+      // Ensure query is refetched each time the component is mounted to keep data updated
+      this.$apollo.queries.blockPage.refetch()
+  }
+
   destroyed() {
     if (this.connectedSubscription) {
       this.connectedSubscription.unsubscribe()

--- a/apps/explorer/src/modules/charts/components/live/ChartLiveTxs.vue
+++ b/apps/explorer/src/modules/charts/components/live/ChartLiveTxs.vue
@@ -121,8 +121,8 @@ export default class ChartLiveTxs extends Vue {
   }
 
   mounted() {
-      // Ensure query is refetched each time the component is mounted to keep data updated
-      this.$apollo.queries.blockPage.refetch()
+    // Ensure query is refetched each time the component is mounted to keep data updated
+    this.$apollo.queries.blockPage.refetch()
   }
 
   destroyed() {


### PR DESCRIPTION
Live charts queries must be re-fetched when components are mounted to avoid displaying stale data from apollo cache.