### PR TITLE
WIP: Feature/balance deltas with txs

### DIFF
--- a/apps/api/src/dao/transfer.service.ts
+++ b/apps/api/src/dao/transfer.service.ts
@@ -174,7 +174,8 @@ export class TransferService {
     }, [] as string [])
 
     // Find related txs and receipts
-    const txs = await this.txService.findByHash(txHashes, false)
+    // There may not be any txs for the transfers array if all transfers are block-related, e.g. MINER_FEE or BLOCK_REWARD
+    const txs = txHashes.length ? await this.txService.findByHash(txHashes, false) : []
 
     return [transfers, txs, hasMore]
 

--- a/apps/api/src/dao/tx.service.ts
+++ b/apps/api/src/dao/tx.service.ts
@@ -30,7 +30,7 @@ export class TxService {
   }
 
   async findOneByHash(hash: string): Promise<TransactionEntity | undefined> {
-    const txs = await this.findByHash(hash)
+    const txs = await this.findByHash([hash])
 
     if (txs.length !== 1) return undefined
 
@@ -54,7 +54,7 @@ export class TxService {
     return tx
   }
 
-  async findByHash(...hashes: string[]): Promise<TransactionEntity[]> {
+  async findByHash(hashes: string[], getTraces: boolean = true): Promise<TransactionEntity[]> {
     const txs = await this.transactionRepository.find({
       where: { hash: In(hashes) },
       relations: ['receipt'],
@@ -62,6 +62,9 @@ export class TxService {
     })
     if (!txs.length) { // User may be searching by hash which does not exist as a tx
       return []
+    }
+    if (!getTraces) { // Don't return traces if not necessary
+      return txs
     }
     return this.findAndMapTraces(txs)
   }

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -27,8 +27,9 @@ export enum DeltaType {
     TOKEN_TRANSFER = "TOKEN_TRANSFER",
     CONTRACT_DESTRUCTION = "CONTRACT_DESTRUCTION",
     TX = "TX",
+    INTERNAL_TX = "INTERNAL_TX",
     MINER_FEE = "MINER_FEE",
-    INTERNAL_TX = "INTERNAL_TX"
+    TX_FEE = "TX_FEE"
 }
 
 export enum Duration {
@@ -542,7 +543,7 @@ export interface Transaction {
     creates?: string;
     chainId?: string;
     receipt?: Receipt;
-    trace: Trace;
+    trace?: Trace;
     successful: boolean;
 }
 
@@ -587,6 +588,7 @@ export interface Transfer {
 export interface TransferPage {
     items: Transfer[];
     hasMore: boolean;
+    txs?: Transaction[];
 }
 
 export interface Uncle {

--- a/apps/api/src/graphql/transfers/dto/balance-delta-page.dto.ts
+++ b/apps/api/src/graphql/transfers/dto/balance-delta-page.dto.ts
@@ -1,15 +1,21 @@
-import { Transfer, TransferPage } from '@app/graphql/schema'
+import { Transaction, Transfer, TransferPage } from '@app/graphql/schema'
 import { assignClean } from '@app/shared/utils'
 import { BalanceDeltaDto } from '@app/graphql/transfers/dto/balance-delta.dto'
+import { TxDto } from '@app/graphql/txs/dto/tx.dto'
 
 export class BalanceDeltaPageDto implements TransferPage {
   items!: Transfer[]
+  txs?: Transaction[]
   hasMore!: boolean
 
   constructor(data: any) {
-    if (data.items) {
-      this.items = data.items.map(i => new BalanceDeltaDto(i))
-      delete data.items
+    if (data.transfers) {
+      this.items = data.transfers.map(i => new BalanceDeltaDto(i))
+      delete data.transfers
+    }
+    if (data.txs) {
+      this.txs = data.txs.map(t => new TxDto(t))
+      delete data.txs
     }
     assignClean(this, data)
   }

--- a/apps/api/src/graphql/transfers/transfer.graphql
+++ b/apps/api/src/graphql/transfers/transfer.graphql
@@ -16,6 +16,7 @@ type Query {
 type TransferPage {
   items: [Transfer!]!
   hasMore: Boolean!
+  txs: [Transaction]
 }
 
 type Transfer {
@@ -67,6 +68,7 @@ enum DeltaType {
   TOKEN_TRANSFER
   CONTRACT_DESTRUCTION
   TX
-  MINER_FEE
   INTERNAL_TX
+  MINER_FEE
+  TX_FEE
 }

--- a/apps/api/src/graphql/transfers/transfer.resolvers.ts
+++ b/apps/api/src/graphql/transfers/transfer.resolvers.ts
@@ -81,7 +81,7 @@ export class TransferResolvers {
     @Args('offset') offset?: number,
     @Args('limit') limit?: number,
   ): Promise<BalanceDeltaPageDto> {
-    const [items, txs, hasMore] = await this.transferService.findBalanceDeltas(addresses, contracts, filter, timestampTo, timestampFrom, offset, limit)
-    return new BalanceDeltaPageDto({ items, hasMore })
+    const [transfers, txs, hasMore] = await this.transferService.findBalanceDeltas(addresses, contracts, filter, timestampTo, timestampFrom, offset, limit)
+    return new BalanceDeltaPageDto({ transfers, txs, hasMore })
   }
 }

--- a/apps/api/src/graphql/transfers/transfer.resolvers.ts
+++ b/apps/api/src/graphql/transfers/transfer.resolvers.ts
@@ -81,7 +81,7 @@ export class TransferResolvers {
     @Args('offset') offset?: number,
     @Args('limit') limit?: number,
   ): Promise<BalanceDeltaPageDto> {
-    const [items, hasMore] = await this.transferService.findBalanceDeltas(addresses, contracts, filter, timestampTo, timestampFrom, offset, limit)
+    const [items, txs, hasMore] = await this.transferService.findBalanceDeltas(addresses, contracts, filter, timestampTo, timestampFrom, offset, limit)
     return new BalanceDeltaPageDto({ items, hasMore })
   }
 }

--- a/apps/api/src/graphql/txs/dto/tx.dto.ts
+++ b/apps/api/src/graphql/txs/dto/tx.dto.ts
@@ -25,7 +25,7 @@ export class TxDto implements Transaction {
   creates?: string;
   chainId?: string;
   receipt?: TxReceiptDto;
-  trace!: TxTraceDto;
+  trace?: TxTraceDto;
   successful!: boolean;
 
   constructor(data: TransactionEntity) {

--- a/apps/api/src/graphql/txs/tx.graphql
+++ b/apps/api/src/graphql/txs/tx.graphql
@@ -53,7 +53,7 @@ type Transaction {
   creates: String
   chainId: String
   receipt: Receipt
-  trace: Trace!
+  trace: Trace
   successful: Boolean!
 }
 


### PR DESCRIPTION
Refactors balanceDeltas query to also return an array of associated txs. Return type is now as follows:
{
items: [Transfer]!
hasMore: Boolean!
txs: [Transaction]
} 

- The "txs" array may be empty if all deltas found are block-related e.g. MINER_FEE or BLOCK_REWARD. 
- If there are multiple deltas related to the same tx, the tx is only returned once.