### PR TITLE
Fix/add total count to token exchange rates query

### DIFF
--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -104,7 +104,7 @@ export class TokenService {
     limit: number = 10,
     offset: number = 0,
     addresses: string[] = [],
-  ): Promise<[TokenExchangeRateEntity[], boolean]> {
+  ): Promise<[TokenExchangeRateEntity[], number]> {
     let order
     switch (sort) {
       case 'price_high':
@@ -133,7 +133,7 @@ export class TokenService {
 
     const findOptions: FindManyOptions = {
       order,
-      take: limit + 1,
+      take: limit,
       skip: offset,
       cache: true,
     }
@@ -143,12 +143,9 @@ export class TokenService {
     }
 
     const items = await this.tokenExchangeRateRepository.find(findOptions)
-    const hasMore = items.length > limit
-    if (hasMore) {
-      items.pop()
-    }
+    const totalCount = await this.tokenExchangeRateRepository.count({ cache: true, where: findOptions.where })
 
-    return [items, hasMore]
+    return [items, totalCount]
   }
 
   async countTokenExchangeRates(): Promise<number> {

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -488,7 +488,7 @@ export interface TokenExchangeRate {
 
 export interface TokenExchangeRatesPage {
     items: TokenExchangeRate[];
-    hasMore: boolean;
+    totalCount: number;
 }
 
 export interface TokenHolder {

--- a/apps/api/src/graphql/tokens/dto/token-exchange-rate-page.dto.ts
+++ b/apps/api/src/graphql/tokens/dto/token-exchange-rate-page.dto.ts
@@ -4,7 +4,7 @@ import { TokenExchangeRateDto } from '@app/graphql/tokens/dto/token-exchange-rat
 
 export class TokenExchangeRatePageDto implements TokenExchangeRatesPage {
   items!: TokenExchangeRateDto[]
-  hasMore!: boolean
+  totalCount!: number
 
   constructor(data: any) {
     if (data.items) {

--- a/apps/api/src/graphql/tokens/token.graphql
+++ b/apps/api/src/graphql/tokens/token.graphql
@@ -43,7 +43,7 @@ type TokenHoldersPage {
 
 type TokenExchangeRatesPage {
   items: [TokenExchangeRate!]!
-  hasMore: Boolean!
+  totalCount: Int!
 }
 
 type TokenExchangeRate {

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -68,8 +68,8 @@ export class TokenResolvers {
     @Args('limit') limit?: number,
     @Args('offset') offset?: number,
   ): Promise<TokenExchangeRatePageDto> {
-    const [items, hasMore] = await this.tokenService.findTokenExchangeRates(sort, limit, offset, addresses)
-    return new TokenExchangeRatePageDto({ items, hasMore })
+    const [items, totalCount] = await this.tokenService.findTokenExchangeRates(sort, limit, offset, addresses)
+    return new TokenExchangeRatePageDto({ items, totalCount })
   }
 
   @Query()

--- a/apps/explorer/apollo/schemas/api.json
+++ b/apps/explorer/apollo/schemas/api.json
@@ -6099,7 +6099,7 @@
             "deprecationReason": null
           },
           {
-            "name": "hasMore",
+            "name": "totalCount",
             "description": null,
             "args": [],
             "type": {
@@ -6107,7 +6107,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Boolean",
+                "name": "Int",
                 "ofType": null
               }
             },

--- a/apps/explorer/src/core/api/apollo/extensions/token-exchange-rate-page.ext.ts
+++ b/apps/explorer/src/core/api/apollo/extensions/token-exchange-rate-page.ext.ts
@@ -49,10 +49,10 @@ export class TokenExchangeRatePageExt_items implements TokenExchangeRatePage_ite
 export class TokenExchangeRatePageExt implements TokenExchangeRatePage {
   __typename!: 'TokenExchangeRatesPage'
   items: TokenExchangeRatePage_items[]
-  hasMore: boolean
+  totalCount: number
 
   constructor(proto: TokenExchangeRatePage) {
     this.items = proto.items.map(i => new TokenExchangeRatePageExt_items(i))
-    this.hasMore = proto.hasMore
+    this.totalCount = proto.totalCount
   }
 }

--- a/apps/explorer/src/core/api/apollo/types/TokenExchangeRatePage.ts
+++ b/apps/explorer/src/core/api/apollo/types/TokenExchangeRatePage.ts
@@ -21,5 +21,5 @@ export interface TokenExchangeRatePage_items {
 export interface TokenExchangeRatePage {
   __typename: "TokenExchangeRatesPage";
   items: TokenExchangeRatePage_items[];
-  hasMore: boolean;
+  totalCount: number;
 }

--- a/apps/explorer/src/core/api/apollo/types/keepAliveUpdates.ts
+++ b/apps/explorer/src/core/api/apollo/types/keepAliveUpdates.ts
@@ -1,0 +1,11 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL subscription operation: keepAliveUpdates
+// ====================================================
+
+export interface keepAliveUpdates {
+  keepAlive: boolean;
+}

--- a/apps/explorer/src/core/api/apollo/types/tokenExchangeRates.ts
+++ b/apps/explorer/src/core/api/apollo/types/tokenExchangeRates.ts
@@ -23,7 +23,7 @@ export interface tokenExchangeRates_tokenExchangeRates_items {
 export interface tokenExchangeRates_tokenExchangeRates {
   __typename: "TokenExchangeRatesPage";
   items: tokenExchangeRates_tokenExchangeRates_items[];
-  hasMore: boolean;
+  totalCount: number;
 }
 
 export interface tokenExchangeRates {

--- a/apps/explorer/src/modules/tokens/components/TokenTable.vue
+++ b/apps/explorer/src/modules/tokens/components/TokenTable.vue
@@ -13,7 +13,7 @@
     <!--    >-->
     <app-table-title page-type="tokens" :title="$tc('token.name', 2)" :has-pagination="hasPagination">
       <template v-slot:pagination v-if="hasPagination">
-        <app-paginate-has-more :has-more="tokenExchangeRatePage.hasMore" @newPage="setPage" :current-page="page" />
+        <app-paginate :total="totalCount" @newPage="setPage" :current-page="page" />
       </template>
     </app-table-title>
     <!--
@@ -104,7 +104,7 @@
             <token-table-row :token="token" />
           </div>
           <v-layout v-if="hasPagination" justify-end row class="pb-1 pr-2 pl-2">
-            <app-paginate-has-more :has-more="tokenExchangeRatePage.hasMore" @newPage="setPage" :current-page="page" />
+            <app-paginate :total="totalCount" @newPage="setPage" :current-page="page" />
           </v-layout>
         </v-flex>
         <v-flex xs12 v-else>
@@ -127,11 +127,9 @@ import TokenTableRowLoading from '@app/modules/tokens/components/TokenTableRowLo
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import { tokenExchangeRates } from '@app/modules/tokens/tokens.graphql'
 import { TokenExchangeRatePageExt } from '@app/core/api/apollo/extensions/token-exchange-rate-page.ext'
-import AppPaginateHasMore from '@app/core/components/ui/AppPaginateHasMore.vue'
 
 @Component({
   components: {
-    AppPaginateHasMore,
     AppError,
     AppPaginate,
     AppTableTitle,
@@ -267,15 +265,15 @@ export default class TokenTable extends Vue {
     return !!this.error && this.error !== ''
   }
 
-  // get totalCount(): number {
-  //   return this.tokenExchangeRatePage ? this.tokenExchangeRatePage.totalCount : 0
-  // }
+  get totalCount(): number {
+    return this.tokenExchangeRatePage ? this.tokenExchangeRatePage.totalCount : 0
+  }
 
-  // get pages(): number {
-  //   return this.tokenExchangeRatePage ? Math.ceil(this.tokenExchangeRatePage!.totalCount / this.maxItems) : 0
-  // }
+  get pages(): number {
+    return this.tokenExchangeRatePage ? Math.ceil(this.tokenExchangeRatePage!.totalCount / this.maxItems) : 0
+  }
   get hasPagination(): boolean {
-    return !!(!this.hasError && (this.page > 0 || (this.tokenExchangeRatePage && this.tokenExchangeRatePage.hasMore)))
+    return !this.hasError && this.pages > 1
   }
 }
 </script>

--- a/apps/explorer/src/modules/tokens/tokens.graphql
+++ b/apps/explorer/src/modules/tokens/tokens.graphql
@@ -19,7 +19,7 @@ fragment TokenExchangeRatePage on TokenExchangeRatesPage {
   items {
     ...TokenExchangeRate
   }
-  hasMore
+  totalCount
 }
 
 query tokenDetails($address: String!) {


### PR DESCRIPTION
Reverts tokenExchangeRates query to returning page with totalCount field as on review the dataset is small enough to perform a count query