### PR TITLE
fix: do nothing on sync status history when processing duplicates

### DIFF
--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
@@ -450,6 +450,7 @@ abstract class AbstractProcessor<V>(protected val processorId: String) : KoinCom
     txCtx
       .insertInto(SYNC_STATUS_HISTORY)
       .set(record)
+      .onConflictDoNothing()    // we do nothing as we may be re-processing duplicate blocks as the result of a restart
       .execute()
 
     // update latest


### PR DESCRIPTION
When a processor restarts it goes 3 hours back in time in case any forks happened. As a result we process duplicates initially. It's possible that we try to insert a `sync_status_history` record with the same block number due to how our batching works. In that instance we should not modify the history table.