### PR TITLE
Fix: unnecessary processor cache state rebuilds

### DIFF
--- a/apps/processing/connectors/sources/web3/src/main/kotlin/com/ethvm/kafka/connect/sources/web3/ext/ParityExt.kt
+++ b/apps/processing/connectors/sources/web3/src/main/kotlin/com/ethvm/kafka/connect/sources/web3/ext/ParityExt.kt
@@ -4,9 +4,7 @@ import org.web3j.protocol.Web3jService
 import org.web3j.protocol.core.DefaultBlockParameter
 import org.web3j.protocol.core.Request
 import org.web3j.protocol.core.Response
-import org.web3j.protocol.core.methods.response.TransactionReceipt
 import org.web3j.protocol.parity.JsonRpc2_0Parity
-import org.web3j.protocol.parity.methods.response.Trace
 import java.math.BigInteger
 import java.util.Arrays
 
@@ -33,7 +31,6 @@ class JsonRpc2_0ParityExtended(web3jService: Web3jService) : JsonRpc2_0Parity(we
       EthvmBlocksResponse::class.java
     )
   }
-
 }
 
 class EthChainIdResponse : Response<String>() {

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockCountsCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockCountsCache.kt
@@ -108,7 +108,6 @@ class BlockCountsCache(
         cacheStores.forEach { it.clear() }
         lastChangeBlockNumber = BigInteger.ONE.negate()
       }
-
     }
 
     // disable history generation until we have initialised
@@ -346,7 +345,6 @@ class BlockCountsCache(
 
       // update our local latest block number
       metadataMap["lastChangeBlockNumber"] = lastChangeBlockNumberDb(txCtx)
-
     }
 
     cacheStores.forEach { it.flushToDisk() }

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockHashCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockHashCache.kt
@@ -72,7 +72,7 @@ class BlockHashCache(
 
     cursor.close()
 
-    logger.info { "[$processorId] Initialisation complete. $count records loaded" }
+    logger.info { "[$processorId] Initialisation complete. $count entries processed" }
   }
 
   fun reset(txCtx: DSLContext) {

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockTimestampCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockTimestampCache.kt
@@ -34,6 +34,7 @@ class BlockTimestampCache(
 
   fun initialise(txCtx: DSLContext) {
 
+    logger.info { "Initialising" }
     // load the last n block timestamps from the database
 
     val cursor = txCtx
@@ -43,6 +44,8 @@ class BlockTimestampCache(
       .limit(historySize)
       .fetchLazy()
 
+    var count = 0
+
     while (cursor.hasNext()) {
 
       val next = cursor.fetchNext()
@@ -50,10 +53,13 @@ class BlockTimestampCache(
 
       memoryMap[blockNumber] = next.value2().time
 
-      logger.info { "[$processorId] Reloaded block number = $blockNumber" }
+      logger.debug { "[$processorId] Reloaded block number = $blockNumber" }
+      count += 1
     }
 
     cursor.close()
+
+    logger.info { "Initialisation complete. $count entries processed" }
   }
 
   operator fun set(number: BigInteger, timestamp: Long) {

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/FungibleBalanceCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/FungibleBalanceCache.kt
@@ -106,7 +106,6 @@ class FungibleBalanceCache(
         cacheStores.forEach { it.clear() }
         lastChangeBlockNumber = BigInteger.ONE.negate()
       }
-
     }
 
     // disable db record generation until initialisation is complete
@@ -202,7 +201,6 @@ class FungibleBalanceCache(
       .limit(1)
       .fetchOne()
       ?.value1()?.toBigInteger() ?: BigInteger.ONE.negate()
-
 
   fun get(address: String, contractAddress: String?): BigInteger? {
     // TODO optimize serialization
@@ -331,7 +329,6 @@ class FungibleBalanceCache(
 
       // update last block number where changes occurred locally
       metadataMap["lastChangeBlockNumber"] = lastChangeBlockNumberFromDb(txCtx)
-
     }
 
     cacheStores.forEach { it.flushToDisk() }
@@ -474,12 +471,10 @@ class FungibleBalanceCache(
 
       // re-enable generation of history records
       writeHistoryToDb = true
-
     } else {
 
       logger.info { "[$tokenType] Clearing all cache stores" }
       cacheStores.forEach { it.clear() }
-
     }
 
     logger.info { "[$tokenType] Flushing cache stores to disk" }

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/FungibleBalanceCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/FungibleBalanceCache.kt
@@ -90,8 +90,6 @@ class FungibleBalanceCache(
 
     var latestBlockNumber = metadataMap["latestBlockNumber"] ?: BigInteger.ONE.negate()
 
-    logger.info { "Latest block number from metadata map: $latestBlockNumber" }
-
     // get latest processed block number from db
 
     val latestDbBlockNumber = txCtx
@@ -103,12 +101,13 @@ class FungibleBalanceCache(
       .fetchOne()
       ?.value1()?.toBigInteger() ?: BigInteger.ONE.negate()
 
-    logger.info { "[$tokenType] Init state. Last processed block number (local): $latestBlockNumber, last processed block number from db: $latestDbBlockNumber" }
+    logger.info { "[$tokenType] Last processed block number (local): $latestBlockNumber, last processed block number from db: $latestDbBlockNumber" }
 
     when {
 
       latestBlockNumber == latestDbBlockNumber -> {
         logger.info { "[$tokenType] Nothing to synchronise. Initialisation complete" }
+        return
       }
 
       latestBlockNumber > latestDbBlockNumber -> {

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/InternalTxsCountsCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/InternalTxsCountsCache.kt
@@ -81,7 +81,6 @@ class InternalTxsCountsCache(
         cacheStores.forEach { it.clear() }
         lastChangeBlockNumber = BigInteger.ONE.negate()
       }
-
     }
 
     // replay any missed state
@@ -313,11 +312,10 @@ class InternalTxsCountsCache(
         .batchInsert(historyRecords)
         .execute()
 
-      if(historyRecords.isNotEmpty()) {
+      if (historyRecords.isNotEmpty()) {
         // update latest block number where changes occurred
         metadataMap["lastChangeBlockNumber"] = lastChangeBlockNumberDb(txCtx)
       }
-
     }
 
     cacheStores.forEach { it.flushToDisk() }
@@ -409,7 +407,6 @@ class InternalTxsCountsCache(
 
       // re-enable db record generation
       writeHistoryToDb = true
-
     } else {
 
       // just clear everything

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/NonFungibleBalanceCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/NonFungibleBalanceCache.kt
@@ -73,7 +73,6 @@ class NonFungibleBalanceCache(
         cacheStores.forEach { it.clear() }
         lastChangeBlockNumber = BigInteger.ONE.negate()
       }
-
     }
 
     val cursor = txCtx

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
@@ -408,7 +408,7 @@ abstract class AbstractProcessor<V>(protected val processorId: String) : KoinCom
         consumer.commitSync()
 
         val last = records.last()
-        logger.info { "Kafka batch complete. Count = ${records.count()}, head = ${last.key().number.bigInteger()}, block timestamp = ${last.timestamp()}" }
+        logger.debug { "Kafka batch complete. Count = ${records.count()}, head = ${last.key().number.bigInteger()}, block timestamp = ${Date(last.timestamp())}" }
       }
     } catch (e: Exception) {
 

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
@@ -156,7 +156,7 @@ abstract class AbstractProcessor<V>(protected val processorId: String) : KoinCom
       val latestSyncStatus = getLatestSyncRecord(dbContext)
       val latestBlockNumber = latestSyncStatus?.blockNumber?.toBigInteger() ?: BigInteger.ONE.negate()
 
-      logger.info { "Latest sync block number = $latestBlockNumber" }
+      logger.info { "Last processed block number = $latestBlockNumber" }
 
       // call the implementation initialise method
 

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
@@ -379,7 +379,6 @@ abstract class AbstractProcessor<V>(protected val processorId: String) : KoinCom
 
                     process(txCtx, record)
                     hashCache[blockNumber] = blockHashFor(record.value())
-
                   }
                 }
 
@@ -401,7 +400,6 @@ abstract class AbstractProcessor<V>(protected val processorId: String) : KoinCom
 
               logger.info { "Tx elapsed time = $txElapsedTimeMs ms. Record count = $recordCount. Latest block number = $lastBlockNumber, block time = ${Date(lastRecord!!.timestamp())}" }
             }
-
         }
 
         // commit to kafka
@@ -416,7 +414,6 @@ abstract class AbstractProcessor<V>(protected val processorId: String) : KoinCom
       diskDb.rollback()
 
       logger.error(e) { "Fatal exception, stopping" }
-
     } finally {
 
       close()
@@ -450,7 +447,7 @@ abstract class AbstractProcessor<V>(protected val processorId: String) : KoinCom
     txCtx
       .insertInto(SYNC_STATUS_HISTORY)
       .set(record)
-      .onConflictDoNothing()    // we do nothing as we may be re-processing duplicate blocks as the result of a restart
+      .onConflictDoNothing() // we do nothing as we may be re-processing duplicate blocks as the result of a restart
       .execute()
 
     // update latest

--- a/apps/processing/processor/src/main/resources/logback.xml
+++ b/apps/processing/processor/src/main/resources/logback.xml
@@ -13,7 +13,8 @@
 
     <logger name="com.ethvm" level="INFO"/>
     <logger name="org.apache.kafka" level="WARN"/>
-    <logger name="org.jooq" level="INFO"/>
+    <logger name="io.confluent" level = "WARN"/>
+    <logger name="org.jooq" level="WARN"/>
 
 
 </configuration>


### PR DESCRIPTION
When restarting processors they were rebuilding all local state from the database despite the fact they had been cleanly shutdown and therefore should be in sync with the db.

The underlying issue was in how each state cache was tracking their latest processed block number. Locally they were recording the last block number they were asked to process. On initialisation they were determining the latest processed block number from the db by looking for the latest entries within specific tables relating to their state. 

The problem is when there has been no changes for several blocks, such as no balance changes. For the state caches they had locally recorded a later block number than was present within the db. 

By adjusting how the state caches locally record their latest block number, instead basing it on the latest entry from the database at the end of a batch or during rewind, it keeps the state tracking consistent with the db and avoids any unnecessary state rebuilds.