### PR TITLE
Fix: out of memory on initialisation

### DIFF
--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockCountsCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockCountsCache.kt
@@ -40,7 +40,7 @@ class BlockCountsCache(
     Serializer.STRING,
     Serializer.BIG_INTEGER,
     BigInteger.ZERO,
-    1024  // 1 kb
+    1024 // 1 kb
   )
 
   private val canonicalCountMap = CacheStore(
@@ -51,7 +51,7 @@ class BlockCountsCache(
     Serializer.STRING,
     Serializer.LONG,
     0L,
-    1024  // 1 kb
+    1024 // 1 kb
   )
 
   private val txCountByAddress =
@@ -65,7 +65,7 @@ class BlockCountsCache(
       TransactionCountRecord
         .newBuilder()
         .build(),
-      1024 * 1024 * 64  // 64 mb
+      1024 * 1024 * 64 // 64 mb
     )
 
   private val minedCountByAddress =
@@ -77,7 +77,7 @@ class BlockCountsCache(
       Serializer.STRING,
       Serializer.LONG,
       0L,
-      1024 * 1024 * 32  // 32 mb
+      1024 * 1024 * 32 // 32 mb
     )
 
   // list of all cache stores for convenience later

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockHashCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/BlockHashCache.kt
@@ -19,13 +19,14 @@ import java.util.concurrent.ScheduledExecutorService
 class BlockHashCache(
   memoryDb: DB,
   scheduledExecutor: ScheduledExecutorService,
-  private val processorId: String
+  private val processorId: String,
+  private val dbFetchSize: Int = 512
 ) {
 
   val logger = KotlinLogging.logger {}
 
   // the n last blocks we reload from the database on initialisation
-  private val historySize = 1_000_000
+  private val historySize = 10240
 
   private val memoryMap = memoryDb
     .hashMap("block_hashes_$processorId")
@@ -54,7 +55,7 @@ class BlockHashCache(
         .where(PROCESSOR_HASH_LOG.PROCESSOR_ID.eq(processorId))
         .orderBy(PROCESSOR_HASH_LOG.BLOCK_NUMBER.desc())
         .limit(historySize)
-        .fetchSize(1000)
+        .fetchSize(dbFetchSize)
         .fetchLazy()
 
     var count = 0

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/CacheStore.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/CacheStore.kt
@@ -15,7 +15,7 @@ class CacheStore<K, V>(
   keySerializer: Serializer<K>,
   valueSerializer: Serializer<V>,
   defaultValue: V,
-  maxMemorySize: Int = 16384
+  maxMemorySize: Int = 1024 * 1024   // default is 1 mb
 ) {
 
   // persistent on disk
@@ -30,7 +30,7 @@ class CacheStore<K, V>(
     .hashMap(name)
     .keySerializer(keySerializer)
     .valueSerializer(valueSerializer)
-    .expireMaxSize(maxMemorySize.toLong())
+    .expireStoreSize(maxMemorySize.toLong())
     .expireAfterGet()
     .expireOverflow(overflowMap)
     .expireExecutor(scheduledExecutor)

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/CacheStore.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/CacheStore.kt
@@ -15,7 +15,7 @@ class CacheStore<K, V>(
   keySerializer: Serializer<K>,
   valueSerializer: Serializer<V>,
   defaultValue: V,
-  maxMemorySize: Int = 1024 * 1024   // default is 1 mb
+  maxMemorySize: Int = 1024 * 1024 // default is 1 mb
 ) {
 
   // persistent on disk

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/FungibleBalanceCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/FungibleBalanceCache.kt
@@ -39,7 +39,7 @@ class FungibleBalanceCache(
     Serializer.STRING,
     Serializer.BIG_INTEGER,
     BigInteger.ZERO,
-    1024  // 1kb
+    1024 // 1kb
   )
 
   // for tracking fungible balances such as ether or erc20
@@ -51,7 +51,7 @@ class FungibleBalanceCache(
     Serializer.STRING,
     Serializer.BIG_INTEGER,
     BigInteger.ZERO,
-    1024 * 1024 * 128   // 128 mb
+    1024 * 1024 * 128 // 128 mb
   )
 
   // for tracking the total number of fungible tokens an address has
@@ -63,7 +63,7 @@ class FungibleBalanceCache(
     Serializer.STRING,
     Serializer.LONG,
     0L,
-    1024 * 1024 * 32  // 32 mb
+    1024 * 1024 * 32 // 32 mb
   )
 
   // for tracking the total number of non zero balance holders of a fungible token
@@ -75,7 +75,7 @@ class FungibleBalanceCache(
     Serializer.STRING,
     Serializer.LONG,
     0L,
-    1024 * 1024 * 16  // 16 mb
+    1024 * 1024 * 16 // 16 mb
   )
 
   // convenience list of all cache stores

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/FungibleBalanceCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/FungibleBalanceCache.kt
@@ -24,7 +24,8 @@ class FungibleBalanceCache(
   diskDb: DB,
   scheduledExecutor: ScheduledExecutorService,
   private val tokenType: TokenType,
-  processorId: String
+  processorId: String,
+  private val dbFetchSize: Int = 512
 ) {
 
   val logger = KotlinLogging.logger {}
@@ -37,7 +38,8 @@ class FungibleBalanceCache(
     "${processorId}_fungible_balances_metadata",
     Serializer.STRING,
     Serializer.BIG_INTEGER,
-    BigInteger.ZERO
+    BigInteger.ZERO,
+    1024  // 1kb
   )
 
   // for tracking fungible balances such as ether or erc20
@@ -48,7 +50,8 @@ class FungibleBalanceCache(
     "${processorId}_fungible_balances",
     Serializer.STRING,
     Serializer.BIG_INTEGER,
-    BigInteger.ZERO
+    BigInteger.ZERO,
+    1024 * 1024 * 128   // 128 mb
   )
 
   // for tracking the total number of fungible tokens an address has
@@ -59,7 +62,8 @@ class FungibleBalanceCache(
     "${processorId}_address_fungible_token_balance_count",
     Serializer.STRING,
     Serializer.LONG,
-    0L
+    0L,
+    1024 * 1024 * 32  // 32 mb
   )
 
   // for tracking the total number of non zero balance holders of a fungible token
@@ -70,7 +74,8 @@ class FungibleBalanceCache(
     "${processorId}_fungible_token_holder_count",
     Serializer.STRING,
     Serializer.LONG,
-    0L
+    0L,
+    1024 * 1024 * 16  // 16 mb
   )
 
   // convenience list of all cache stores
@@ -117,7 +122,7 @@ class FungibleBalanceCache(
       .selectFrom(BALANCE)
       .where(BALANCE.TOKEN_TYPE.eq(tokenType.toString()))
       .and(BALANCE.BLOCK_NUMBER.gt(lastChangeBlockNumber.toBigDecimal()))
-      .fetchSize(1000)
+      .fetchSize(dbFetchSize)
       .fetchLazy()
 
     var count = 0
@@ -125,7 +130,7 @@ class FungibleBalanceCache(
     while (balanceCursor.hasNext()) {
       set(balanceCursor.fetchNext())
       count += 1
-      if (count % 10000 == 0) {
+      if (count % dbFetchSize == 0) {
         cacheStores.forEach { it.flushToDisk(true) }
         logger.info { "[$tokenType] $count deltas processed" }
       }
@@ -143,13 +148,13 @@ class FungibleBalanceCache(
       .selectFrom(ADDRESS_TOKEN_COUNT)
       .where(ADDRESS_TOKEN_COUNT.BLOCK_NUMBER.gt(lastChangeBlockNumber.toBigDecimal()))
       .and(ADDRESS_TOKEN_COUNT.TOKEN_TYPE.eq(tokenType.toString()))
-      .fetchSize(1000)
+      .fetchSize(dbFetchSize)
       .fetchLazy()
 
     while (addressTokenCountCursor.hasNext()) {
       set(addressTokenCountCursor.fetchNext())
       count += 1
-      if (count % 10000 == 0) {
+      if (count % dbFetchSize == 0) {
         cacheStores.forEach { it.flushToDisk(true) }
         logger.info { "[$tokenType] $count address token counts processed" }
       }
@@ -167,13 +172,13 @@ class FungibleBalanceCache(
       .selectFrom(CONTRACT_HOLDER_COUNT)
       .where(CONTRACT_HOLDER_COUNT.BLOCK_NUMBER.gt(lastChangeBlockNumber.toBigDecimal()))
       .and(CONTRACT_HOLDER_COUNT.TOKEN_TYPE.eq(tokenType.toString()))
-      .fetchSize(1000)
+      .fetchSize(dbFetchSize)
       .fetchLazy()
 
     while (contractHolderCountCursor.hasNext()) {
       set(contractHolderCountCursor.fetchNext())
       count += 1
-      if (count % 10000 == 0) {
+      if (count % dbFetchSize == 0) {
         cacheStores.forEach { it.flushToDisk(true) }
         logger.info { "[$tokenType] $count contract holder counts processed" }
       }
@@ -399,7 +404,7 @@ class FungibleBalanceCache(
         .where(BALANCE_DELTA.BLOCK_NUMBER.ge(blockNumberDecimal))
         .and(BALANCE_DELTA.TOKEN_TYPE.eq(tokenTypeStr))
         .orderBy(BALANCE_DELTA.BLOCK_NUMBER.desc())
-        .fetchSize(1000)
+        .fetchSize(dbFetchSize)
         .fetchLazy()
 
       while (cursor.hasNext()) {

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/InternalTxsCountsCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/InternalTxsCountsCache.kt
@@ -32,7 +32,7 @@ class InternalTxsCountsCache(
     TransactionCountRecord
       .newBuilder()
       .build(),
-    1024 * 1024 * 32  // 32 mb
+    1024 * 1024 * 32 // 32 mb
   )
 
   private val contractsCreatedByAddress = CacheStore(
@@ -43,7 +43,7 @@ class InternalTxsCountsCache(
     Serializer.STRING,
     Serializer.LONG,
     0L,
-    1024 * 1024 * 16  // 16 mb
+    1024 * 1024 * 16 // 16 mb
   )
 
   private val metadataMap = CacheStore(
@@ -54,7 +54,7 @@ class InternalTxsCountsCache(
     Serializer.STRING,
     Serializer.BIG_INTEGER,
     BigInteger.ZERO,
-    1024  // 1 kb
+    1024 // 1 kb
   )
 
   private val cacheStores = listOf(internalTxCountByAddress, contractsCreatedByAddress, metadataMap)

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/NonFungibleBalanceCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/NonFungibleBalanceCache.kt
@@ -17,7 +17,8 @@ class NonFungibleBalanceCache(
   diskDb: DB,
   scheduledExecutor: ScheduledExecutorService,
   private val tokenType: TokenType,
-  processorId: String
+  processorId: String,
+  private val dbFetchSize: Int = 512
 ) {
 
   val logger = KotlinLogging.logger {}
@@ -29,7 +30,8 @@ class NonFungibleBalanceCache(
     "${processorId}_non_fungible_balances",
     Serializer.STRING,
     Serializer.BIG_INTEGER,
-    BigInteger.ZERO
+    BigInteger.ZERO,
+    1024 * 1024 * 128   // 128 mb
   )
 
   private val metadataMap = CacheStore(
@@ -39,7 +41,8 @@ class NonFungibleBalanceCache(
     "${processorId}_non_fungible_balances_metadata",
     Serializer.STRING,
     Serializer.BIG_INTEGER,
-    BigInteger.ZERO
+    BigInteger.ZERO,
+    1024
   )
 
   // convenience lists
@@ -79,7 +82,7 @@ class NonFungibleBalanceCache(
       .selectFrom(BALANCE)
       .where(BALANCE.TOKEN_TYPE.eq(tokenType.toString()))
       .and(BALANCE.BLOCK_NUMBER.gt(lastChangeBlockNumber.toBigDecimal()))
-      .fetchSize(1000)
+      .fetchSize(dbFetchSize)
       .fetchLazy()
 
     writeHistoryToDb = false
@@ -89,7 +92,7 @@ class NonFungibleBalanceCache(
     while (cursor.hasNext()) {
       assign(cursor.fetchNext())
       count += 1
-      if (count % 1000 == 0) {
+      if (count % dbFetchSize == 0) {
         cacheStores.forEach { it.flushToDisk(true) }
         logger.info { "[$tokenType] $count deltas processed" }
       }
@@ -203,7 +206,7 @@ class NonFungibleBalanceCache(
       .where(BALANCE_DELTA.BLOCK_NUMBER.ge(blockNumber.toBigDecimal()))
       .and(BALANCE_DELTA.TOKEN_TYPE.eq(tokenType.toString()))
       .orderBy(BALANCE_DELTA.BLOCK_NUMBER.desc())
-      .fetchSize(1000)
+      .fetchSize(dbFetchSize)
       .fetchLazy()
 
     // temporarily disable

--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/NonFungibleBalanceCache.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/cache/NonFungibleBalanceCache.kt
@@ -31,7 +31,7 @@ class NonFungibleBalanceCache(
     Serializer.STRING,
     Serializer.BIG_INTEGER,
     BigInteger.ZERO,
-    1024 * 1024 * 128   // 128 mb
+    1024 * 1024 * 128 // 128 mb
   )
 
   private val metadataMap = CacheStore(


### PR DESCRIPTION
When starting the processors the process was running out of memory whilst rebuilding cache store state from the database. 

The following fixes and refinements have been applied to prevent this:

- Fixing the use of the MapDb API for specifying max in memory db size for cache stores
- Reducing the db fetch size during initialisation and rewind phases 
- Increasing the frequency with which cache stores are flushed during the initialisation phase

Testing with a 2Gb max heap size have shown memory to be stable, however it is recommended to run a more thorough test with a large amount of database statet to rebuild before deploying to production.