### PR TITLE
fix: commit disk db after processor initialisation

### DIFF
--- a/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
+++ b/apps/processing/processor/src/main/kotlin/com/ethvm/processing/processors/AbstractProcessor.kt
@@ -167,6 +167,9 @@ abstract class AbstractProcessor<V>(protected val processorId: String) : KoinCom
 
       initialise(txCtx, latestBlockNumber)
 
+      // commit cache changes to disk
+      diskDb.commit()
+
       logger.info { "initialised" }
     }
 


### PR DESCRIPTION
We should flush any cache stores changes to disk after processor initialisation instead of relying upon the first processed batch for the flush. This creates a window in which changes for a costly cache rebuild could be lost and would require another rebuild.