### PR TITLE
Fix/token detail by address

### DIFF
--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -285,6 +285,6 @@ export class TokenService {
   }
 
   async findDetailByAddress(address: string, blockNumber: BigNumber): Promise<TokenDetailEntity | undefined> {
-    return this.tokenDetailRepository.findOne({where: [{ address }, {  }], cache: true})
+    return this.tokenDetailRepository.findOne({where: { address, createdAtBlockNumber: LessThanOrEqual(blockNumber) }, cache: true})
   }
 }

--- a/apps/api/src/dao/token.service.ts
+++ b/apps/api/src/dao/token.service.ts
@@ -284,7 +284,7 @@ export class TokenService {
     return [items, hasMore]
   }
 
-  async findDetailByAddress(address: string): Promise<TokenDetailEntity | undefined> {
-    return this.tokenDetailRepository.findOne({where: {address}, cache: true})
+  async findDetailByAddress(address: string, blockNumber: BigNumber): Promise<TokenDetailEntity | undefined> {
+    return this.tokenDetailRepository.findOne({where: [{ address }, {  }], cache: true})
   }
 }

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -13,7 +13,7 @@ import {TokenMetadataPageDto} from '@app/graphql/tokens/dto/token-metadata-page.
 import {TokenDetailDto} from '@app/graphql/tokens/dto/token-detail.dto'
 import {TokenBalancePageDto} from '@app/graphql/tokens/dto/token-balance-page.dto'
 import {BlockNumberPipe} from '@app/shared/pipes/block-number.pipe'
-import {ExchangeRatePair, TokenExchangeRateFilter} from '@app/graphql/schema';
+import {ExchangeRatePair, TokenExchangeRateFilter} from '@app/graphql/schema'
 
 @Resolver('Token')
 @UseInterceptors(SyncingInterceptor)

--- a/apps/api/src/graphql/tokens/token.resolvers.ts
+++ b/apps/api/src/graphql/tokens/token.resolvers.ts
@@ -132,7 +132,7 @@ export class TokenResolvers {
     if (!blockNumber) { // There is no data
       return undefined
     }
-    const entity = await this.tokenService.findDetailByAddress(address)
+    const entity = await this.tokenService.findDetailByAddress(address, blockNumber)
     if (!entity) return undefined
     const holdersCount = await this.tokenService.countTokenHolders(address, blockNumber)
     return new TokenDetailDto({...entity, holdersCount})

--- a/apps/api/src/orm/entities/token-detail.entity.ts
+++ b/apps/api/src/orm/entities/token-detail.entity.ts
@@ -19,6 +19,9 @@ export class TokenDetailEntity {
   @Column({ type: 'varchar', length: 32, readonly: true })
   contractType?: string
 
+  @Column({ type: 'numeric', readonly: true, transformer: new BigNumberTransformer() })
+  createdAtBlockNumber!: BigNumber
+
   @Column({type: 'character varying', length: 64, readonly: true})
   name?: string
 

--- a/apps/migrator/migrations/V2__Initial_Views.sql
+++ b/apps/migrator/migrations/V2__Initial_Views.sql
@@ -45,6 +45,7 @@ CREATE VIEW token_detail AS
 SELECT c.address,
        c.creator,
        c.contract_type,
+       c.created_at_block_number,
        elcm.name,
        elcm.symbol,
        elcm.decimals,

--- a/apps/migrator/migrations/V2__Initial_Views.sql
+++ b/apps/migrator/migrations/V2__Initial_Views.sql
@@ -45,7 +45,6 @@ CREATE VIEW token_detail AS
 SELECT c.address,
        c.creator,
        c.contract_type,
-       c.created_at_block_number,
        elcm.name,
        elcm.symbol,
        elcm.decimals,

--- a/apps/migrator/migrations/V3__Update_token_detail_view.sql
+++ b/apps/migrator/migrations/V3__Update_token_detail_view.sql
@@ -1,0 +1,32 @@
+DROP VIEW token_detail;
+
+CREATE VIEW token_detail AS
+SELECT c.address,
+       c.creator,
+       c.contract_type,
+       c.created_at_block_number,
+       elcm.name,
+       elcm.symbol,
+       elcm.decimals,
+       elcm.logo,
+       elcm.support,
+       elcm.social,
+       elcm.website,
+       ter.current_price,
+       ter.circulating_supply,
+       ter.total_supply,
+       ter.market_cap,
+       ter.price_change_percentage24h,
+       ter.total_volume,
+       ter.name          AS ter_name,
+       ter.symbol        AS ter_symbol,
+       ter.image,
+       cm.name         AS cm_name,
+       cm.symbol       AS cm_symbol,
+       cm.decimals     AS cm_decimals,
+       cm.total_supply AS cm_total_supply
+FROM contract AS c
+       LEFT JOIN eth_list_contract_metadata AS elcm ON c.address = elcm.address
+       LEFT JOIN token_exchange_rate AS ter ON c.address = ter.address
+       LEFT JOIN contract_metadata AS cm ON c.address = cm.address
+WHERE c.contract_type IN ('ERC20', 'ERC721');


### PR DESCRIPTION
Updates tokenDetailByAddress query to better take into account the blockNumber param. 

Previously, token_detail was not filtered by the blockNumber as there was no block_number field on the view. This meant it was possible to return details for a contract which had not yet been created (as of the blockNumber param). This could be a problem if the contract lifecycle processor was far ahead of other processors).

To overcome this, created_at_block_number field was added to the token_detail view in a new migration, so that the query can now filter by the blockNumber provided.