### PR TITLE
version: bump processors to 0.5.0.5

### DIFF
--- a/apps/processing/version.properties
+++ b/apps/processing/version.properties
@@ -1,1 +1,1 @@
-version=0.5.0.4
+version=0.5.0.5


### PR DESCRIPTION
This PR brings version 0.5.0.5 to processors (includes the following fixes):

- Fix for memory leak with MapDB
- Improved minor logging