### PR TITLE
bug: display transactions for block details with param Hash;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ### Release v1.0.1
 
-### Bug 
+### Bug
+
 - Fix BLOCKS pagination is not taking block 0 into account [#850] (https://github.com/EthVM/EthVM/pull/850)
 - Only hide filter on initialLoad [#848] (https://github.com/EthVM/EthVM/pull/848)
 - Fix Search All by address by adding isValidAddress check [#847] (https://github.com/EthVM/EthVM/pull/847)
-
+- Fix block transaction if route param of the block details is hash
+- Fix block parent route changed to hash

--- a/newclient/src/modules/blocks/handlers/BlockDetails/BlockDetails.vue
+++ b/newclient/src/modules/blocks/handlers/BlockDetails/BlockDetails.vue
@@ -57,6 +57,9 @@ import newBlockFeed from '../../NewBlockSubscription/newBlockFeed.graphql'
             update: data => data.getBlockByHash || data.getBlockByNumber,
             result({ data }) {
                 if (this.block) {
+                    if (this.isHash) {
+                        this.emitBlockNumber()
+                    }
                     this.$emit('isMined', true)
                     this.emitErrorState(false)
                 }
@@ -160,7 +163,7 @@ export default class BlockDetails extends Mixins(NumberFormatMixin, NewBlockSubs
                 {
                     title: this.$i18n.t('block.p-hash'),
                     detail: this.block.parentHash!,
-                    link: `/block/number/${this.block.summary.number - 1}`,
+                    link: `/block/hash/${this.block.parentHash}`,
                     copy: true,
                     mono: true
                 },
@@ -316,6 +319,9 @@ export default class BlockDetails extends Mixins(NumberFormatMixin, NewBlockSubs
     emitErrorState(val: boolean): void {
         this.hasError = val
         this.$emit('errorDetails', this.hasError, ErrorMessageBlock.details)
+    }
+    emitBlockNumber(): void {
+        this.$emit('setBlockNumber', this.block.summary.number.toString())
     }
 }
 </script>

--- a/newclient/src/modules/blocks/pages/PageDetailsBlock.vue
+++ b/newclient/src/modules/blocks/pages/PageDetailsBlock.vue
@@ -9,7 +9,7 @@
       DETAILS LIST
     =====================================================================================
     -->
-        <block-details v-if="isValid" :block-ref="blockRef" :is-hash="isHash" @errorDetails="setError" @isMined="setIsMined" />
+        <block-details v-if="isValid" :block-ref="blockRef" :is-hash="isHash" @errorDetails="setError" @isMined="setIsMined" @setBlockNumber="setBlockNumber" />
 
         <!--
     =====================================================================================
@@ -18,9 +18,9 @@
     -->
         <!-- TODO: Implement get block transfers by hash -->
         <block-txs
-            v-if="isValid && !isHash"
+            v-if="isValid && hasNumber"
             :max-items="maxItems"
-            :block-ref="blockRef"
+            :block-ref="blockNumber"
             :is-hash="isHash"
             :is-mined="isMined"
             page-type="blockDetails"
@@ -71,6 +71,7 @@ export default class PageDetailsBlock extends Vue {
 
     errorMessages: ErrorMessageBlock[] = []
     isMined = false
+    blockNumber: string = ''
 
     /*
     ===================================================================================
@@ -81,6 +82,11 @@ export default class PageDetailsBlock extends Vue {
     created() {
         window.scrollTo(0, 0)
     }
+    mounted() {
+        if (!this.isHash) {
+            this.blockNumber = this.blockRef
+        }
+    }
 
     /*
     ===================================================================================
@@ -90,6 +96,9 @@ export default class PageDetailsBlock extends Vue {
 
     setIsMined(value: boolean): void {
         this.isMined = true
+    }
+    setBlockNumber(value: string): void {
+        this.blockNumber = value
     }
 
     setError(hasError: boolean, message: ErrorMessageBlock): void {
@@ -123,6 +132,9 @@ export default class PageDetailsBlock extends Vue {
 
     get isHash(): boolean {
         return eth.isValidHash(this.blockRef)
+    }
+    get hasNumber(): boolean {
+        return this.blockNumber !== ''
     }
 
     /**


### PR DESCRIPTION
Bug fix

-  Will display block transaction if route param of the block details is hash
-  Block parent route changed to hash