### PR TITLE
replaced router-link-tag with a-tag

### DIFF
--- a/newclient/src/core/components/layout/TheFooter.vue
+++ b/newclient/src/core/components/layout/TheFooter.vue
@@ -91,7 +91,7 @@
                         <v-flex xs12>
                             <v-layout justify-start align-center fill-height pa-2>
                                 <p class="info--text text-xs-left caption pl-2">
-                                    {{ $t('footer.pricing') }} <router-link to="https://www.coingecko.com/">Coingecko.</router-link>
+                                    {{ $t('footer.pricing') }} <a href="https://www.coingecko.com/">Coingecko.</a>
                                 </p>
                             </v-layout>
                         </v-flex>


### PR DESCRIPTION
Replaced router-link-tag with a-tag, because `<router-link to="https://www.coingecko.com/">Coingecko.</router-link>` would link to '/https://www.coingecko.com/' instead of 'https://www.coingecko.com/