### PR TITLE
fix: chart rendering with options update on different units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed x and y are too far apart with stepSize of 1 minute [#947](https://github.com/EthVM/EthVM/pull/947)
 - Fixed 'Cannot set property 'font' of null' [#947](https://github.com/EthVM/EthVM/pull/947)
 - Cannot read property 'skip' of undefined [#947](https://github.com/EthVM/EthVM/pull/947)
+- Corrected data points within unique charts for duration [#947](https://github.com/EthVM/EthVM/pull/947)
 
 ### Devop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@
 - Fixed 'Cannot set property 'font' of null' [#947](https://github.com/EthVM/EthVM/pull/947)
 - Cannot read property 'skip' of undefined [#947](https://github.com/EthVM/EthVM/pull/947)
 - Corrected data points within unique charts for duration [#947](https://github.com/EthVM/EthVM/pull/947)
+- Fixed 'From timestampe is larger than to timestamp' in uniqe charts [#947](https://github.com/EthVM/EthVM/pull/947)
 
 ### Devop
 
 - Bump ini from 1.3.5 to 1.3.8 [#943](https://github.com/EthVM/EthVM/pull/943)
 - Change Unique chart route names [#942](https://github.com/EthVM/EthVM/pull/942)
+- Implemented handler for undefined results in getTimeseriesData [#947](https://github.com/EthVM/EthVM/pull/947)
+- Refactor logic for home transactions chart to correct display updated data points in lines [#947](https://github.com/EthVM/EthVM/pull/947)
 
 ===================================================================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ### Release v1.0.6
+
 ### Bug
+
 - Prevent searching an empty string & remove onlyLetters [#944](https://github.com/EthVM/EthVM/pull/944)
+- Fixed x and y are too far apart with stepSize of 1 minute [#924](https://github.com/EthVM/EthVM/pull/947)
+- Fixed 'Cannot set property 'font' of null' (https://github.com/EthVM/EthVM/pull/947)
 
 ### Devop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ### Bug
 
 - Prevent searching an empty string & remove onlyLetters [#944](https://github.com/EthVM/EthVM/pull/944)
-- Fixed x and y are too far apart with stepSize of 1 minute [#924](https://github.com/EthVM/EthVM/pull/947)
-- Fixed 'Cannot set property 'font' of null' (https://github.com/EthVM/EthVM/pull/947)
+- Fixed x and y are too far apart with stepSize of 1 minute [#947](https://github.com/EthVM/EthVM/pull/947)
+- Fixed 'Cannot set property 'font' of null' [#947](https://github.com/EthVM/EthVM/pull/947)
+- Cannot read property 'skip' of undefined [#947](https://github.com/EthVM/EthVM/pull/947)
 
 ### Devop
 

--- a/newclient/src/apollo/schemas/api.json
+++ b/newclient/src/apollo/schemas/api.json
@@ -1420,6 +1420,22 @@
             "deprecationReason": null
           },
           {
+            "name": "getTimestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "checkAddress",
             "description": null,
             "args": [

--- a/newclient/src/modules/address/handlers/AddressOverview/apolloTypes/getContractTimestamp.ts
+++ b/newclient/src/modules/address/handlers/AddressOverview/apolloTypes/getContractTimestamp.ts
@@ -1,0 +1,21 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: getContractTimestamp
+// ====================================================
+
+export interface getContractTimestamp_getTransactionByHash {
+  __typename: "Tx";
+  timestamp: number | null;
+}
+
+export interface getContractTimestamp {
+  getTransactionByHash: getContractTimestamp_getTransactionByHash;
+}
+
+export interface getContractTimestampVariables {
+  hash: string;
+}

--- a/newclient/src/modules/charts/components/Chart.vue
+++ b/newclient/src/modules/charts/components/Chart.vue
@@ -52,7 +52,15 @@
           Chart Body
         =====================================================================================
         -->
-        <line-chart :chart-data="datacollection" :chart-options="chartOptions"></line-chart>
+        <div class="chart-card">
+            <line-chart v-if="!isLoadingData" :chart-data="datacollection" :chart-options="chartOptions" pa-2></line-chart>
+            <v-layout v-else column fill-height align-center pa-2>
+                <div class="chart-icon-container">
+                    <v-icon class="primary--text fas fa-circle-notch fa-spin chart-icon" />
+                </div>
+            </v-layout>
+        </div>
+
         <!--
         =====================================================================================
          Footnotes
@@ -163,6 +171,7 @@ export default class Chart extends Vue {
     @Prop({ type: Object }) chartOptions!: ChartOptions
     @Prop({ type: Boolean, default: true }) showTimeOptions!: boolean
     @Prop({ type: Boolean, default: false }) isPending!: boolean
+    @Prop({ type: Boolean, default: true }) isLoadingData!: boolean
 
     /*
     ===================================================================================
@@ -193,15 +202,7 @@ export default class Chart extends Vue {
     Computed
   ===================================================================================
   */
-    get chartClass(): string {
-        const brkPoint = this.$vuetify.breakpoint.name
-        switch (brkPoint) {
-            case 'xs':
-                return 'xs-chart'
-            default:
-                return ''
-        }
-    }
+
     get description(): string {
         if (!this.showTimeOptions) {
             return this.chartDescription
@@ -242,8 +243,14 @@ export default class Chart extends Vue {
     padding: 2px;
 }
 
-.xs-chart {
-    min-height: 280px;
+.chart-card {
+    min-height: 400px;
+}
+
+.chart-icon-container {
+    height: 2em;
+    width: 2em;
+    margin-top: 150px;
 }
 
 .chart-caption {

--- a/newclient/src/modules/charts/handlers/HomeGasPriceChart.vue
+++ b/newclient/src/modules/charts/handlers/HomeGasPriceChart.vue
@@ -7,6 +7,7 @@
             :chart-options="chartOptions"
             :footnotes="footnotes"
             :show-time-options="false"
+            :is-loading-data="loading"
         />
     </div>
 </template>
@@ -293,6 +294,9 @@ export default class HomeGasPriceChart extends Mixins(ChartDataMixin) {
                 icon: 'fa fa-circle'
             }
         ]
+    }
+    get loading(): boolean {
+        return this.$apollo.queries.dataGasMin.loading
     }
     /*
     ===================================================================================

--- a/newclient/src/modules/charts/handlers/HomeGasPriceChart.vue
+++ b/newclient/src/modules/charts/handlers/HomeGasPriceChart.vue
@@ -18,7 +18,10 @@ import Chart from '@app/modules/charts/components/Chart.vue'
 import { ChartDataMixin } from '@app/modules/charts/mixins/ChartDataMixin.mixin'
 import { TimeseriesKey, DataPoint, ChartData, Dataset, ChartOptions, TimeseriesValue } from '@app/modules/charts/models'
 import { TimeseriesScale } from '@app/apollo/global/globalTypes'
-import { getTimeseriesData_getTimeseriesData as GetTimeseriesDataType } from '@app/modules/charts/handlers/apolloTypes/getTimeseriesData'
+import {
+    getTimeseriesData_getTimeseriesData as GetTimeseriesDataType,
+    getTimeseriesData_getTimeseriesData_items as TimeseriesDataItem
+} from '@app/modules/charts/handlers/apolloTypes/getTimeseriesData'
 import { getTimeseriesData, timeseriesEthAvg } from '@app/modules/charts/handlers/timeseriesData.graphql'
 import { Footnote } from '@app/core/components/props'
 
@@ -40,6 +43,9 @@ const MAX_ITEMS = 10
             variables() {
                 return this.getQueryVars(KEY_GAS_MIN, SCALE, START)
             },
+            skip() {
+                return this.loadingOffset
+            },
             subscribeToMore: {
                 document: timeseriesEthAvg,
                 variables() {
@@ -53,6 +59,9 @@ const MAX_ITEMS = 10
                             return previousResult
                         }
                         const newItems = this.addSubscriptionItem(newItem, prevItems)
+                        while (newItems.length > MAX_ITEMS) {
+                            newItems.shift()
+                        }
                         return {
                             getTimeseriesData: {
                                 __typename: previousResult.getTimeseriesData.__typename,
@@ -65,13 +74,21 @@ const MAX_ITEMS = 10
             },
             update: data => (data.getTimeseriesData ? data.getTimeseriesData.items : null),
             result({ data }) {
-                this.gasMinDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                if (data && data.getTimeseriesData && data.getTimeseriesData.items && data.getTimeseriesData.items.length > 0) {
+                    this.gasMinDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                }
+            },
+            error(error) {
+                this.hasErrorGasMin = true
             }
         },
         dataGasMax: {
             query: getTimeseriesData,
             variables() {
                 return this.getQueryVars(KEY_GAS_MAX, SCALE, START)
+            },
+            skip() {
+                return this.loadingOffset
             },
             subscribeToMore: {
                 document: timeseriesEthAvg,
@@ -86,6 +103,9 @@ const MAX_ITEMS = 10
                             return previousResult
                         }
                         const newItems = this.addSubscriptionItem(newItem, prevItems)
+                        while (newItems.length > MAX_ITEMS) {
+                            newItems.shift()
+                        }
                         return {
                             getTimeseriesData: {
                                 __typename: previousResult.getTimeseriesData.__typename,
@@ -98,13 +118,21 @@ const MAX_ITEMS = 10
             },
             update: data => (data.getTimeseriesData ? data.getTimeseriesData.items : null),
             result({ data }) {
-                this.gasMaxDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                if (data && data.getTimeseriesData && data.getTimeseriesData.items && data.getTimeseriesData.items.length > 0) {
+                    this.gasMaxDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                }
+            },
+            error(error) {
+                this.hasErrorGasMax = true
             }
         },
         dataGasAvg: {
             query: getTimeseriesData,
             variables() {
                 return this.getQueryVars(KEY_GAS_AVG, SCALE, START)
+            },
+            skip() {
+                return this.loadingOffset
             },
             subscribeToMore: {
                 document: timeseriesEthAvg,
@@ -119,6 +147,9 @@ const MAX_ITEMS = 10
                             return previousResult
                         }
                         const newItems = this.addSubscriptionItem(newItem, prevItems)
+                        while (newItems.length > MAX_ITEMS) {
+                            newItems.shift()
+                        }
                         return {
                             getTimeseriesData: {
                                 __typename: previousResult.getTimeseriesData.__typename,
@@ -131,7 +162,12 @@ const MAX_ITEMS = 10
             },
             update: data => (data.getTimeseriesData ? data.getTimeseriesData.items : null),
             result({ data }) {
-                this.gasAvgDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                if (data && data.getTimeseriesData && data.getTimeseriesData.items && data.getTimeseriesData.items.length > 0) {
+                    this.gasAvgDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                }
+            },
+            error(error) {
+                this.hasErrorGasAvg = true
             }
         }
     }
@@ -151,12 +187,16 @@ export default class HomeGasPriceChart extends Mixins(ChartDataMixin) {
     ===================================================================================
     */
 
-    dataGasMin!: GetTimeseriesDataType
-    dataGasMax!: GetTimeseriesDataType
-    dataGasAvg!: GetTimeseriesDataType
+    dataGasMin!: TimeseriesDataItem
+    dataGasMax!: TimeseriesDataItem
+    dataGasAvg!: TimeseriesDataItem
     gasMinDataSet: DataPoint[] = []
     gasMaxDataSet: DataPoint[] = []
     gasAvgDataSet: DataPoint[] = []
+
+    hasErrorGasMin = false
+    hasErrorGasMax = false
+    hasErrorGasAvg = false
 
     /*
     ===================================================================================
@@ -296,39 +336,9 @@ export default class HomeGasPriceChart extends Mixins(ChartDataMixin) {
         ]
     }
     get loading(): boolean {
-        return this.$apollo.queries.dataGasMin.loading
-    }
-    /*
-    ===================================================================================
-      Watchers
-    ===================================================================================
-    */
-    @Watch('gasMinDataSet', { deep: true })
-    ongasMinDataSetChanged(newVal) {
-        if (newVal.length > MAX_ITEMS) {
-            newVal.shift()
-            this.gasMinDataSet = newVal
-        } else {
-            this.gasMinDataSet = newVal
-        }
-    }
-    @Watch('gasMaxDataSet', { deep: true })
-    ongasMaxDataSetChanged(newVal) {
-        if (newVal.length > MAX_ITEMS) {
-            newVal.shift()
-            this.gasMaxDataSet = newVal
-        } else {
-            this.gasMaxDataSet = newVal
-        }
-    }
-    @Watch('gasAvgDataSet', { deep: true })
-    ongasAvgDataSetChanged(newVal) {
-        if (newVal.length > MAX_ITEMS) {
-            newVal.shift()
-            this.gasAvgDataSet = newVal
-        } else {
-            this.gasAvgDataSet = newVal
-        }
+        const loadingQueries = this.$apollo.queries.dataGasMin.loading || this.$apollo.queries.dataGasMax.loading || this.$apollo.queries.dataGasAvg.loading
+        const hasError = this.hasErrorGasMin && this.hasErrorGasMax && this.hasErrorGasAvg
+        return this.loadingOffset || loadingQueries || hasError
     }
 }
 </script>

--- a/newclient/src/modules/charts/handlers/HomeTxChart.vue
+++ b/newclient/src/modules/charts/handlers/HomeTxChart.vue
@@ -18,7 +18,10 @@ import Chart from '@app/modules/charts/components/Chart.vue'
 import { ChartDataMixin } from '@app/modules/charts/mixins/ChartDataMixin.mixin'
 import { TimeseriesKey, DataPoint, ChartData, Dataset, ChartOptions, TimeseriesValue } from '@app/modules/charts/models'
 import { TimeseriesScale } from '@app/apollo/global/globalTypes'
-import { getTimeseriesData_getTimeseriesData as GetTimeseriesDataType } from '@app/modules/charts/handlers/apolloTypes/getTimeseriesData'
+import {
+    getTimeseriesData_getTimeseriesData as GetTimeseriesDataType,
+    getTimeseriesData_getTimeseriesData_items as TimeseriesDataItem
+} from '@app/modules/charts/handlers/apolloTypes/getTimeseriesData'
 import { getTimeseriesData, timeseriesEthAvg } from '@app/modules/charts/handlers/timeseriesData.graphql'
 import { Footnote } from '@app/core/components/props'
 
@@ -39,6 +42,9 @@ const MAX_ITEMS = 10
             variables() {
                 return this.getQueryVars(KEY_TX_TOTAL, SCALE, START)
             },
+            skip() {
+                return this.loadingOffset
+            },
             subscribeToMore: {
                 document: timeseriesEthAvg,
                 variables() {
@@ -51,7 +57,10 @@ const MAX_ITEMS = 10
                         if (!newItem) {
                             return previousResult
                         }
-                        const newItems = this.addSubscriptionItem(newItem, prevItems)
+                        const newItems = this.addSubscriptionItem(newItem, prevItems, MAX_ITEMS)
+                        while (newItems.length > MAX_ITEMS) {
+                            newItems.shift()
+                        }
                         return {
                             getTimeseriesData: {
                                 __typename: previousResult.getTimeseriesData.__typename,
@@ -64,13 +73,21 @@ const MAX_ITEMS = 10
             },
             update: data => (data.getTimeseriesData ? data.getTimeseriesData.items : null),
             result({ data }) {
-                this.txTotalDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                if (data && data.getTimeseriesData && data.getTimeseriesData.items && data.getTimeseriesData.items.length > 0) {
+                    this.txTotalDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                }
+            },
+            error(error) {
+                this.hasErrorTxTotal = true
             }
         },
         dataTxPen: {
             query: getTimeseriesData,
             variables() {
                 return this.getQueryVars(KEY_TX_PEN, SCALE, START)
+            },
+            skip() {
+                return this.loadingOffset
             },
             subscribeToMore: {
                 document: timeseriesEthAvg,
@@ -84,8 +101,10 @@ const MAX_ITEMS = 10
                         if (!newItem) {
                             return previousResult
                         }
-                        const newItems = this.addSubscriptionItem(newItem, prevItems)
-
+                        const newItems = this.addSubscriptionItem(newItem, prevItems, MAX_ITEMS)
+                        while (newItems.length > MAX_ITEMS) {
+                            newItems.shift()
+                        }
                         return {
                             getTimeseriesData: {
                                 __typename: previousResult.getTimeseriesData.__typename,
@@ -98,7 +117,12 @@ const MAX_ITEMS = 10
             },
             update: data => (data.getTimeseriesData ? data.getTimeseriesData.items : null),
             result({ data }) {
-                this.txPenDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                if (data && data.getTimeseriesData && data.getTimeseriesData.items && data.getTimeseriesData.items.length > 0) {
+                    this.txPenDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, VALUE_TYPE)]
+                }
+            },
+            error(error) {
+                this.hasErrorTxPen = true
             }
         }
     }
@@ -110,10 +134,12 @@ export default class HomeTxChart extends Mixins(ChartDataMixin) {
     ===================================================================================
     */
 
-    dataTxTotal!: GetTimeseriesDataType
-    dataTxPen!: GetTimeseriesDataType
+    dataTxTotal!: (TimeseriesDataItem | null)[]
+    dataTxPen!: (TimeseriesDataItem | null)[]
     txTotalDataSet: DataPoint[] = []
     txPenDataSet: DataPoint[] = []
+    hasErrorTxTotal = false
+    hasErrorTxPen = false
 
     /*
     ===================================================================================
@@ -128,11 +154,44 @@ export default class HomeTxChart extends Mixins(ChartDataMixin) {
         return `${this.$t('charts.tx-summary.description')}`
     }
 
+    /**
+     * Array of Total Txs points aligned with the pending timestamp
+     * 0 values are set when data point was not found in the dataTotalTxs, due to data
+     * not being avaialble in the DB.
+     * Futher results are mapped to the teh DataPoint Type
+     * @return
+     * - DataPoint[] if dataTotalTxs and dataTxPen queries returned results
+     * - null otherwise
+     */
+    get totalTxs(): DataPoint[] | null {
+        if (this.txTotalDataSet.length > 0 && this.txPenDataSet.length > 0) {
+            const _items = this.dataTxPen.map((txPen, index) => {
+                if (txPen) {
+                    const point = this.dataTxTotal.find(element => {
+                        if (element) {
+                            return element.timestamp === txPen.timestamp
+                        }
+                        return undefined
+                    })
+                    return {
+                        __typename: txPen.__typename,
+                        timestamp: txPen.timestamp,
+                        value: point ? point.value : '0'
+                    }
+                }
+                return null
+            })
+
+            return this.mapItemsToDataSet(_items, VALUE_TYPE)
+        }
+        return null
+    }
+
     get chartData(): ChartData | null {
         const _datasets: Dataset[] = []
-        if (this.txTotalDataSet) {
+        if (this.totalTxs) {
             _datasets.push({
-                data: this.txTotalDataSet,
+                data: this.totalTxs,
                 label: `${this.$t('charts.tx-summary.label.total')}`,
                 borderColor: '#00b173',
                 backgroundColor: '#00b173',
@@ -158,6 +217,7 @@ export default class HomeTxChart extends Mixins(ChartDataMixin) {
         }
         return null
     }
+
     get chartOptions(): ChartOptions {
         return {
             responsive: true,
@@ -238,32 +298,11 @@ export default class HomeTxChart extends Mixins(ChartDataMixin) {
             }
         ]
     }
-    get loading(): boolean {
-        return this.$apollo.queries.dataTxTotal.loading
-    }
 
-    /*
-    ===================================================================================
-      Watchers
-    ===================================================================================
-    */
-    @Watch('txTotalDataSet', { deep: true })
-    ongasMinDataSetChanged(newVal) {
-        if (newVal.length > MAX_ITEMS) {
-            newVal.shift()
-            this.txTotalDataSet = newVal
-        } else {
-            this.txTotalDataSet = newVal
-        }
-    }
-    @Watch('txPenDataSet', { deep: true })
-    ongasMaxDataSetChanged(newVal) {
-        if (newVal.length > MAX_ITEMS) {
-            newVal.shift()
-            this.txPenDataSet = newVal
-        } else {
-            this.txPenDataSet = newVal
-        }
+    get loading(): boolean {
+        const loadingQueries = this.$apollo.queries.dataTxTotal.loading || this.$apollo.queries.dataTxPen.loading
+        const hasError = this.hasErrorTxTotal && this.hasErrorTxPen
+        return this.loadingOffset || loadingQueries || hasError
     }
 }
 </script>

--- a/newclient/src/modules/charts/handlers/HomeTxChart.vue
+++ b/newclient/src/modules/charts/handlers/HomeTxChart.vue
@@ -7,6 +7,7 @@
             :chart-options="chartOptions"
             :footnotes="footnotes"
             :show-time-options="false"
+            :is-loading-data="loading"
         />
     </div>
 </template>
@@ -236,6 +237,9 @@ export default class HomeTxChart extends Mixins(ChartDataMixin) {
                 icon: 'fa fa-circle'
             }
         ]
+    }
+    get loading(): boolean {
+        return this.$apollo.queries.dataTxTotal.loading
     }
 
     /*

--- a/newclient/src/modules/charts/handlers/TimeSeriesChartData.vue
+++ b/newclient/src/modules/charts/handlers/TimeSeriesChartData.vue
@@ -6,6 +6,7 @@
             :datacollection="chartData"
             :chart-options="chartOptions"
             :is-pending="isPending"
+            :is-loading-data="loading"
             @timeFrame="setTimeFrame"
         />
     </div>
@@ -169,6 +170,7 @@ const DEFAULT_DATA: ComponentDataInterface = {
             update: data => (data.getTimeseriesData ? data.getTimeseriesData.items : null),
             result({ data }) {
                 this.chartDataSet = [...this.mapItemsToDataSet(data.getTimeseriesData.items, this.value_type)]
+                this.loadingData = false
             }
         }
     }
@@ -187,6 +189,8 @@ export default class TimeSeriesChartData extends Mixins(ChartDataMixin) {
     maxItems = DEFAULT_DATA[0].max_items
     start = DEFAULT_DATA[0].start
     timeOptions = DEFAULT_DATA[0].timeOptions
+    loadingData = true
+    currentUnit = DEFAULT_DATA[0].timeOptions.unit
 
     /*
     ===================================================================================
@@ -270,6 +274,9 @@ export default class TimeSeriesChartData extends Mixins(ChartDataMixin) {
             }
         }
     }
+    get loading(): boolean {
+        return this.loadingData
+    }
 
     /*
     ===================================================================================
@@ -281,11 +288,14 @@ export default class TimeSeriesChartData extends Mixins(ChartDataMixin) {
      * @param value {Number}
      */
     setTimeFrame(value: number): void {
+        if (this.currentUnit !== DEFAULT_DATA[value].timeOptions.unit) {
+            this.loadingData = true
+            this.currentUnit = DEFAULT_DATA[value].timeOptions.unit
+        }
         this.scale = DEFAULT_DATA[value].scale
         this.maxItems = DEFAULT_DATA[value].max_items
         this.start = DEFAULT_DATA[value].start
         this.timeOptions = DEFAULT_DATA[value].timeOptions
-        this.$apollo.queries.getChartData.refetch()
     }
 }
 </script>

--- a/newclient/src/modules/charts/handlers/TimeSeriesChartData.vue
+++ b/newclient/src/modules/charts/handlers/TimeSeriesChartData.vue
@@ -64,7 +64,7 @@ const DEFAULT_DATA: ComponentDataInterface = {
         start: 24,
         max_items: 24,
         timeOptions: {
-            unit: 'minute',
+            unit: 'hour',
             displayFormats: {
                 minute: 'h:mm a'
             },
@@ -77,7 +77,7 @@ const DEFAULT_DATA: ComponentDataInterface = {
         start: 168,
         max_items: 168,
         timeOptions: {
-            unit: 'day',
+            unit: 'hour',
             displayFormats: {
                 day: 'ddd, h:mm a'
             },

--- a/newclient/src/modules/charts/mixins/apolloTypes/getTimestamp.ts
+++ b/newclient/src/modules/charts/mixins/apolloTypes/getTimestamp.ts
@@ -1,0 +1,12 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: getTimestamp
+// ====================================================
+
+export interface getTimestamp {
+  getTimestamp: string;
+}

--- a/newclient/src/modules/charts/mixins/getServerTimestamp.graphql
+++ b/newclient/src/modules/charts/mixins/getServerTimestamp.graphql
@@ -1,0 +1,3 @@
+query getTimestamp {
+    getTimestamp
+}

--- a/newclient/src/modules/txs/handlers/TxDetails/apolloTypes/getTransactionByHash.ts
+++ b/newclient/src/modules/txs/handlers/TxDetails/apolloTypes/getTransactionByHash.ts
@@ -23,6 +23,7 @@ export interface getTransactionByHash_getTransactionByHash {
   transactionIndex: number | null;
   value: string;
   replacedBy: string | null;
+  contractAddress: string | null;
 }
 
 export interface getTransactionByHash {


### PR DESCRIPTION
This fixes bugs when switching between different time options on unique charts:

- x and y are too far apart with stepSize of 1 minute
- Cannot set property 'font' of null
- Cannot read property 'skip' of undefined
- Cannot read property 'getTimeseriesData' of undefined
- GraphQL execution errors: 'From timestamp is larger than to timestamp'