### PR TITLE
Chore/readme pnpm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Release v2.1.10
+
+### Docs
+
+-   Suggest older pnpm version in README instructions for lockfile compatibility
+
 ### Release v2.1.9
 
 ### UI

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can run Sepolia front end locally, you will need:
 
 *Prerequisites*
 - Node version 18.0.0
+- pnpm version 6.35.1
 - pnpm, [installation guide](https://pnpm.io/installation). 
 
 1. Open terminal


### PR DESCRIPTION
## Describe your changes:
Suggests a specific pnpm version compatible with the EthVM pnpm lockfile in the README setup instructions.

The current EthVM pnpm lockfile version is v5 which is not supported by recent pnpm versions. Using a recent pnpm version that does not support v5 pnpm lockfiles causes large changes to the pnpm lockfile and doesn't support `pnpm install --frozen-lockfile` which can cause inconsistencies and issues with PR's.

## Type of change
Please delete options that are not relevant.

- [x] Docs

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have removed hard coded strings
- [x] I have added entry to ./changelog
- [x] I have added pr label
- [x] I have commented my code, particularly in hard-to-understand areas
